### PR TITLE
MCP Plugin Performance Optimizations

### DIFF
--- a/addons/godot_mcp/plugin.gd
+++ b/addons/godot_mcp/plugin.gd
@@ -5,13 +5,40 @@ extends EditorPlugin
 
 const MCPClientScript = preload("res://addons/godot_mcp/mcp_client.gd")
 const ToolExecutorScript = preload("res://addons/godot_mcp/tool_executor.gd")
+# Tools that touch the editor UI / scene tree and MUST run on the main thread.
+const MAIN_THREAD_TOOLS: Array[StringName] = [
+	&"get_console_log",
+	&"get_errors",
+	&"clear_console_log",
+	&"open_in_godot",
+	&"scene_tree_dump",
+	&"get_node_properties",
+]
+# Tools safe to run on a background thread (pure read, no editor API calls).
+# Everything else runs on the main thread (filesystem refresh, editor UI, etc.).
+const BACKGROUND_SAFE_TOOLS: Array[StringName] = [
+	&"list_dir",
+	&"read_file",
+	&"search_project",
+	&"list_scripts",
+	&"map_project",
+	&"map_scenes",
+	&"validate_script",
+]
 
-var _mcp_client: Node  # MCPClient
-var _tool_executor: Node  # ToolExecutor
+var _mcp_client: MCPClient # MCPClient
+var _tool_executor: ToolExecutor # ToolExecutor
 var _status_label: Label
+var _thread: Thread
+var _mutex: Mutex
+var _pending_requests: Array = [] # [{id, tool, args}]
+var _thread_running := false
+
 
 func _enter_tree() -> void:
 	print("[Godot MCP] Plugin loading...")
+
+	_mutex = Mutex.new()
 
 	# Create MCP client
 	_mcp_client = MCPClientScript.new()
@@ -21,8 +48,8 @@ func _enter_tree() -> void:
 	# Create tool executor
 	_tool_executor = ToolExecutorScript.new()
 	_tool_executor.name = "ToolExecutor"
-	add_child(_tool_executor)  # _ready() runs here, creating child tools
-	_tool_executor.set_editor_plugin(self)  # Now _visualizer_tools exists
+	add_child(_tool_executor) # _ready() runs here, creating child tools
+	_tool_executor.set_editor_plugin(self) # Now _visualizer_tools exists
 
 	# Connect signals
 	_mcp_client.connected.connect(_on_connected)
@@ -37,8 +64,15 @@ func _enter_tree() -> void:
 
 	print("[Godot MCP] Plugin loaded - connecting to MCP server...")
 
+
 func _exit_tree() -> void:
 	print("[Godot MCP] Plugin unloading...")
+
+	# Stop accepting new work and wait for the background thread to finish
+	_thread_running = false
+	if _thread and _thread.is_started():
+		_thread.wait_to_finish()
+	_thread = null
 
 	if _mcp_client:
 		_mcp_client.disconnect_from_server()
@@ -53,39 +87,83 @@ func _exit_tree() -> void:
 
 	print("[Godot MCP] Plugin unloaded")
 
+
 func _setup_status_indicator() -> void:
 	"""Add a small status label to the editor toolbar."""
 	_status_label = Label.new()
 	_status_label.text = "MCP: Connecting..."
-	_status_label.add_theme_color_override("font_color", Color.YELLOW)
-	_status_label.add_theme_font_size_override("font_size", 12)
+	_status_label.add_theme_color_override(&"font_color", Color.YELLOW)
+	_status_label.add_theme_font_size_override(&"font_size", 12)
 	add_control_to_container(EditorPlugin.CONTAINER_TOOLBAR, _status_label)
+
 
 func _on_connected() -> void:
 	print("[Godot MCP] Connected to MCP server")
 	if _status_label:
 		_status_label.text = "MCP: Connected"
-		_status_label.add_theme_color_override("font_color", Color.GREEN)
+		_status_label.add_theme_color_override(&"font_color", Color.GREEN)
+
 
 func _on_disconnected() -> void:
 	print("[Godot MCP] Disconnected from MCP server")
 	if _status_label:
 		_status_label.text = "MCP: Disconnected"
-		_status_label.add_theme_color_override("font_color", Color.RED)
+		_status_label.add_theme_color_override(&"font_color", Color.RED)
+
 
 func _on_tool_requested(request_id: String, tool_name: String, args: Dictionary) -> void:
 	"""Handle incoming tool request from MCP server."""
 	print("[Godot MCP] Executing tool: ", tool_name)
 
-	# Execute the tool
-	var result: Dictionary = _tool_executor.execute_tool(tool_name, args)
+	# Only pure-read tools go to the background thread; everything else
+	# stays on the main thread (filesystem refresh, editor UI, etc.).
+	if StringName(tool_name) not in BACKGROUND_SAFE_TOOLS:
+		var result: Dictionary = _tool_executor.execute_tool(tool_name, args)
+		_send_result(request_id, result)
+		return
 
-	# Send result back
-	var success: bool = result.get("ok", false)
+	# Queue for background execution
+	_mutex.lock()
+	_pending_requests.append({ &"id": request_id, &"tool": tool_name, &"args": args })
+	_mutex.unlock()
+
+	_ensure_thread_running()
+
+
+func _ensure_thread_running() -> void:
+	# Use our own flag — Thread.is_started() stays true until wait_to_finish()
+	if _thread_running:
+		return
+	# Previous thread finished — clean it up before starting a new one
+	if _thread:
+		_thread.wait_to_finish()
+	_thread = Thread.new()
+	_thread_running = true
+	_thread.start(_thread_loop)
+
+
+func _thread_loop() -> void:
+	while _thread_running:
+		# Swap the whole queue out under the lock — O(1) instead of O(n) pop_front
+		_mutex.lock()
+		if _pending_requests.is_empty():
+			_mutex.unlock()
+			_thread_running = false
+			return
+		var batch: Array = _pending_requests
+		_pending_requests = []
+		_mutex.unlock()
+
+		for req: Dictionary in batch:
+			var result: Dictionary = _tool_executor.execute_tool(req[&"tool"], req[&"args"])
+			call_deferred(&"_send_result", req[&"id"], result)
+
+
+func _send_result(request_id: String, result: Dictionary) -> void:
+	var success: bool = result.get(&"ok", false)
 	if success:
-		# Remove 'ok' key from result before sending
-		result.erase("ok")
+		result.erase(&"ok")
 		_mcp_client.send_tool_result(request_id, true, result)
 	else:
-		var error: String = result.get("error", "Unknown error")
+		var error: String = result.get(&"error", "Unknown error")
 		_mcp_client.send_tool_result(request_id, false, null, error)

--- a/addons/godot_mcp/tool_executor.gd
+++ b/addons/godot_mcp/tool_executor.gd
@@ -4,25 +4,77 @@ class_name ToolExecutor
 ## Routes tool invocations to the appropriate handler.
 
 var _editor_plugin: EditorPlugin = null
-
-var _file_tools: Node
-var _scene_tools: Node
-var _script_tools: Node
-var _project_tools: Node
-var _asset_tools: Node
-var _visualizer_tools: Node
-
-# Tool name → [handler_node, method_name]
-var _tool_map: Dictionary = {}
-
+var _file_tools: FileTools
+var _scene_tools: SceneTools
+var _script_tools: ScriptTools
+var _project_tools: ProjectTools
+var _asset_tools: AssetTools
+var _visualizer_tools: VisualizerTools
+var _tool_map: Dictionary = { } # Tool name → [handler_node, method_name]
 var _initialized := false
+
+
+func set_editor_plugin(plugin: EditorPlugin) -> void:
+	_editor_plugin = plugin
+
+	# Initialize tools first (must be done synchronously)
+	_init_tools()
+
+	# Pass editor plugin reference to all tool handlers
+	if _file_tools:
+		_file_tools.set_editor_plugin(plugin)
+	if _scene_tools:
+		_scene_tools.set_editor_plugin(plugin)
+	if _script_tools:
+		_script_tools.set_editor_plugin(plugin)
+	if _project_tools:
+		_project_tools.set_editor_plugin(plugin)
+	if _asset_tools:
+		_asset_tools.set_editor_plugin(plugin)
+	if _visualizer_tools:
+		_visualizer_tools.set_editor_plugin(plugin)
+		# Pass scene_tools reference for visualizer internal scene functions
+		_visualizer_tools.set_scene_tools_ref(_scene_tools)
+
+
+func execute_tool(tool_name: StringName, args: Dictionary) -> Dictionary:
+	"""Execute a tool by name with the given arguments."""
+
+	# Handle internal visualizer commands (not exposed as MCP tools)
+	if tool_name.begins_with("visualizer._internal_"):
+		var method := StringName(tool_name.replace("visualizer.", ""))
+		if _visualizer_tools and _visualizer_tools.has_method(method):
+			return _visualizer_tools.call(method, args)
+		else:
+			return { &"ok": false, &"error": "Internal method not found: " + method }
+
+	if not _tool_map.has(tool_name):
+		return {
+			&"ok": false,
+			&"error": "Unknown tool: %s. Available: %s" % [tool_name, ", ".join(_tool_map.keys())],
+		}
+
+	var handler: Array = _tool_map[tool_name]
+	var node: Node = handler[0]
+	var method: StringName = handler[1]
+
+	if not node.has_method(method):
+		return { &"ok": false, &"error": "Tool handler not found: %s.%s" % [node.name, method] }
+
+	return node.call(method, args)
+
+
+func get_available_tools() -> Array:
+	"""Return list of available tool names."""
+	return _tool_map.keys()
+
 
 func _init_tools() -> void:
 	"""Initialize all tool handlers. Called from set_editor_plugin."""
 	if _initialized:
 		return
 	_initialized = true
-	
+
 	_file_tools = preload("res://addons/godot_mcp/tools/file_tools.gd").new()
 	_file_tools.name = "FileTools"
 	add_child(_file_tools)
@@ -47,103 +99,53 @@ func _init_tools() -> void:
 	_visualizer_tools.name = "VisualizerTools"
 	add_child(_visualizer_tools)
 
-	# Build tool routing map
+	# Build tool routing map (StringName keys for O(1) hash lookups)
 	_tool_map = {
 		# File tools
-		"list_dir": [_file_tools, "list_dir"],
-		"read_file": [_file_tools, "read_file"],
-		"search_project": [_file_tools, "search_project"],
-		"create_script": [_file_tools, "create_script"],
+		&"list_dir": [_file_tools, &"list_dir"],
+		&"read_file": [_file_tools, &"read_file"],
+		&"search_project": [_file_tools, &"search_project"],
+		&"create_script": [_file_tools, &"create_script"],
 
 		# Scene tools
-		"create_scene": [_scene_tools, "create_scene"],
-		"read_scene": [_scene_tools, "read_scene"],
-		"add_node": [_scene_tools, "add_node"],
-		"remove_node": [_scene_tools, "remove_node"],
-		"modify_node_property": [_scene_tools, "modify_node_property"],
-		"rename_node": [_scene_tools, "rename_node"],
-		"move_node": [_scene_tools, "move_node"],
-		"attach_script": [_scene_tools, "attach_script"],
-		"detach_script": [_scene_tools, "detach_script"],
-		"set_collision_shape": [_scene_tools, "set_collision_shape"],
-		"set_sprite_texture": [_scene_tools, "set_sprite_texture"],
-		"get_scene_hierarchy": [_scene_tools, "get_scene_hierarchy"],
-		"get_scene_node_properties": [_scene_tools, "get_scene_node_properties"],
-		"set_scene_node_property": [_scene_tools, "set_scene_node_property"],
+		&"create_scene": [_scene_tools, &"create_scene"],
+		&"read_scene": [_scene_tools, &"read_scene"],
+		&"add_node": [_scene_tools, &"add_node"],
+		&"remove_node": [_scene_tools, &"remove_node"],
+		&"modify_node_property": [_scene_tools, &"modify_node_property"],
+		&"rename_node": [_scene_tools, &"rename_node"],
+		&"move_node": [_scene_tools, &"move_node"],
+		&"attach_script": [_scene_tools, &"attach_script"],
+		&"detach_script": [_scene_tools, &"detach_script"],
+		&"set_collision_shape": [_scene_tools, &"set_collision_shape"],
+		&"set_sprite_texture": [_scene_tools, &"set_sprite_texture"],
+		&"get_scene_hierarchy": [_scene_tools, &"get_scene_hierarchy"],
+		&"get_scene_node_properties": [_scene_tools, &"get_scene_node_properties"],
+		&"set_scene_node_property": [_scene_tools, &"set_scene_node_property"],
 
 		# Script/file management tools
-		"edit_script": [_script_tools, "edit_script"],
-		"validate_script": [_script_tools, "validate_script"],
-		"list_scripts": [_script_tools, "list_scripts"],
-		"create_folder": [_script_tools, "create_folder"],
-		"delete_file": [_script_tools, "delete_file"],
-		"rename_file": [_script_tools, "rename_file"],
+		&"edit_script": [_script_tools, &"edit_script"],
+		&"validate_script": [_script_tools, &"validate_script"],
+		&"list_scripts": [_script_tools, &"list_scripts"],
+		&"create_folder": [_script_tools, &"create_folder"],
+		&"delete_file": [_script_tools, &"delete_file"],
+		&"rename_file": [_script_tools, &"rename_file"],
 
 		# Project/debug tools
-		"get_project_settings": [_project_tools, "get_project_settings"],
-		"get_input_map": [_project_tools, "get_input_map"],
-		"get_collision_layers": [_project_tools, "get_collision_layers"],
-		"get_node_properties": [_project_tools, "get_node_properties"],
-		"get_console_log": [_project_tools, "get_console_log"],
-		"get_errors": [_project_tools, "get_errors"],
-		"clear_console_log": [_project_tools, "clear_console_log"],
-		"open_in_godot": [_project_tools, "open_in_godot"],
-		"scene_tree_dump": [_project_tools, "scene_tree_dump"],
+		&"get_project_settings": [_project_tools, &"get_project_settings"],
+		&"get_input_map": [_project_tools, &"get_input_map"],
+		&"get_collision_layers": [_project_tools, &"get_collision_layers"],
+		&"get_node_properties": [_project_tools, &"get_node_properties"],
+		&"get_console_log": [_project_tools, &"get_console_log"],
+		&"get_errors": [_project_tools, &"get_errors"],
+		&"clear_console_log": [_project_tools, &"clear_console_log"],
+		&"open_in_godot": [_project_tools, &"open_in_godot"],
+		&"scene_tree_dump": [_project_tools, &"scene_tree_dump"],
 
 		# Asset generation tools
-		"generate_2d_asset": [_asset_tools, "generate_2d_asset"],
-		# NOTE: RunningHub tools (inspect_runninghub_workflow, customize_and_run_workflow)
-		# are implemented in asset_tools.gd but not exposed as MCP tools yet.
-		# They require a RunningHub account and will be re-enabled later.
+		&"generate_2d_asset": [_asset_tools, &"generate_2d_asset"],
 
 		# Visualizer tools
-		"map_project": [_visualizer_tools, "map_project"],
-		"map_scenes": [_visualizer_tools, "map_scenes"],
+		&"map_project": [_visualizer_tools, &"map_project"],
+		&"map_scenes": [_visualizer_tools, &"map_scenes"],
 	}
-
-func set_editor_plugin(plugin: EditorPlugin) -> void:
-	_editor_plugin = plugin
-	
-	# Initialize tools first (must be done synchronously)
-	_init_tools()
-	
-	# Pass editor plugin reference to all tool handlers
-	if _file_tools: _file_tools.set_editor_plugin(plugin)
-	if _scene_tools: _scene_tools.set_editor_plugin(plugin)
-	if _script_tools: _script_tools.set_editor_plugin(plugin)
-	if _project_tools: _project_tools.set_editor_plugin(plugin)
-	if _asset_tools: _asset_tools.set_editor_plugin(plugin)
-	if _visualizer_tools:
-		_visualizer_tools.set_editor_plugin(plugin)
-		# Pass scene_tools reference for visualizer internal scene functions
-		_visualizer_tools.set_scene_tools_ref(_scene_tools)
-
-func execute_tool(tool_name: String, args: Dictionary) -> Dictionary:
-	"""Execute a tool by name with the given arguments."""
-	
-	# Handle internal visualizer commands (not exposed as MCP tools)
-	if tool_name.begins_with("visualizer._internal_"):
-		var method: String = tool_name.replace("visualizer.", "")
-		if _visualizer_tools and _visualizer_tools.has_method(method):
-			return _visualizer_tools.call(method, args)
-		else:
-			return {"ok": false, "error": "Internal method not found: " + method}
-	
-	if not _tool_map.has(tool_name):
-		return {
-			"ok": false,
-			"error": "Unknown tool: %s. Available: %s" % [tool_name, ", ".join(_tool_map.keys())]
-		}
-
-	var handler: Array = _tool_map[tool_name]
-	var node: Node = handler[0]
-	var method: String = handler[1]
-
-	if not node.has_method(method):
-		return {"ok": false, "error": "Tool handler not found: %s.%s" % [node.name, method]}
-
-	return node.call(method, args)
-
-func get_available_tools() -> Array:
-	"""Return list of available tool names."""
-	return _tool_map.keys()

--- a/addons/godot_mcp/tools/asset_tools.gd
+++ b/addons/godot_mcp/tools/asset_tools.gd
@@ -18,14 +18,14 @@ func _refresh_filesystem() -> void:
 # generate_2d_asset - Generate PNG from SVG code
 # =============================================================================
 func generate_2d_asset(args: Dictionary) -> Dictionary:
-	var svg_code: String = str(args.get("svg_code", ""))
-	var filename: String = str(args.get("filename", ""))
-	var save_path: String = str(args.get("save_path", "res://assets/generated/"))
+	var svg_code: String = str(args.get(&"svg_code", ""))
+	var filename: String = str(args.get(&"filename", ""))
+	var save_path: String = str(args.get(&"save_path", "res://assets/generated/"))
 
 	if svg_code.strip_edges().is_empty():
-		return {"ok": false, "error": "Missing 'svg_code'"}
+		return {&"ok": false, &"error": "Missing 'svg_code'"}
 	if filename.strip_edges().is_empty():
-		return {"ok": false, "error": "Missing 'filename'"}
+		return {&"ok": false, &"error": "Missing 'filename'"}
 
 	# Ensure .png extension
 	if not filename.ends_with(".png"):
@@ -67,7 +67,7 @@ func generate_2d_asset(args: Dictionary) -> Dictionary:
 	var temp_svg_path := "user://temp_asset.svg"
 	var svg_file := FileAccess.open(temp_svg_path, FileAccess.WRITE)
 	if not svg_file:
-		return {"ok": false, "error": "Failed to create temp SVG file"}
+		return {&"ok": false, &"error": "Failed to create temp SVG file"}
 	svg_file.store_string(svg_code)
 	svg_file.close()
 
@@ -87,15 +87,15 @@ func generate_2d_asset(args: Dictionary) -> Dictionary:
 	var global_path := ProjectSettings.globalize_path(full_path)
 	err = image.save_png(global_path)
 	if err != OK:
-		return {"ok": false, "error": "Failed to save PNG: " + str(err)}
+		return {&"ok": false, &"error": "Failed to save PNG: " + str(err)}
 
 	_refresh_filesystem()
 
 	return {
-		"ok": true,
-		"resource_path": full_path,
-		"dimensions": {"width": width, "height": height},
-		"message": "Generated %s (%dx%d)" % [full_path, width, height]
+		&"ok": true,
+		&"resource_path": full_path,
+		&"dimensions": {&"width": width, &"height": height},
+		&"message": "Generated %s (%dx%d)" % [full_path, width, height]
 	}
 
 # =============================================================================
@@ -105,24 +105,24 @@ func search_comfyui_nodes(args: Dictionary) -> Dictionary:
 	# This tool requires the ComfyUI node database which was bundled with the old plugin
 	# For now, return a message indicating it needs setup
 	return {
-		"ok": true,
-		"results": [],
-		"count": 0,
-		"message": "ComfyUI node search requires the node database. This feature will be available in a future update."
+		&"ok": true,
+		&"results": [],
+		&"count": 0,
+		&"message": "ComfyUI node search requires the node database. This feature will be available in a future update."
 	}
 
 # =============================================================================
 # inspect_runninghub_workflow - Stub (requires API key)
 # =============================================================================
 func inspect_runninghub_workflow(args: Dictionary) -> Dictionary:
-	var workflow_id: String = str(args.get("workflow_id", ""))
+	var workflow_id: String = str(args.get(&"workflow_id", ""))
 	if workflow_id.strip_edges().is_empty():
-		return {"ok": false, "error": "Missing 'workflow_id'"}
+		return {&"ok": false, &"error": "Missing 'workflow_id'"}
 
 	return {
-		"ok": true,
-		"workflow_id": workflow_id,
-		"message": "RunningHub workflow inspection requires API configuration. This feature will be available in a future update."
+		&"ok": true,
+		&"workflow_id": workflow_id,
+		&"message": "RunningHub workflow inspection requires API configuration. This feature will be available in a future update."
 	}
 
 # =============================================================================
@@ -130,6 +130,6 @@ func inspect_runninghub_workflow(args: Dictionary) -> Dictionary:
 # =============================================================================
 func customize_and_run_workflow(args: Dictionary) -> Dictionary:
 	return {
-		"ok": true,
-		"message": "RunningHub workflow execution requires API configuration. This feature will be available in a future update."
+		&"ok": true,
+		&"message": "RunningHub workflow execution requires API configuration. This feature will be available in a future update."
 	}

--- a/addons/godot_mcp/tools/file_tools.gd
+++ b/addons/godot_mcp/tools/file_tools.gd
@@ -6,8 +6,13 @@ class_name FileTools
 
 const DEFAULT_MAX_BYTES := 200_000
 const DEFAULT_MAX_RESULTS := 200
-const SKIP_EXTENSIONS := [".import", ".png", ".jpg", ".jpeg", ".webp", ".svg",
-	".ogg", ".wav", ".mp3", ".escn", ".glb", ".gltf", ".uid"]
+const MAX_TRAVERSAL_DEPTH := 20
+const _SKIP_EXTENSIONS: Dictionary = {
+	".import": true, ".png": true, ".jpg": true, ".jpeg": true,
+	".webp": true, ".svg": true, ".ogg": true, ".wav": true,
+	".mp3": true, ".escn": true, ".glb": true, ".gltf": true,
+	".uid": true,
+}
 
 var _editor_plugin: EditorPlugin = null
 
@@ -18,18 +23,18 @@ func set_editor_plugin(plugin: EditorPlugin) -> void:
 # list_dir - List files and folders in a directory
 # =============================================================================
 func list_dir(args: Dictionary) -> Dictionary:
-	var root: String = str(args.get("root", "res://"))
-	var include_hidden: bool = bool(args.get("include_hidden", false))
+	var root: String = str(args.get(&"root", "res://"))
+	var include_hidden: bool = bool(args.get(&"include_hidden", false))
 
 	if not root.begins_with("res://"):
 		root = "res://" + root
 
 	var dir := DirAccess.open(root)
 	if dir == null:
-		return {"ok": false, "error": "Cannot open directory: " + root}
+		return {&"ok": false, &"error": "Cannot open directory: " + root}
 
-	var files: Array = []
-	var folders: Array = []
+	var files: PackedStringArray = []
+	var folders: PackedStringArray = []
 
 	dir.list_dir_begin()
 	var name := dir.get_next()
@@ -40,11 +45,10 @@ func list_dir(args: Dictionary) -> Dictionary:
 			continue
 
 		# Skip .uid files
-		if name.to_lower().ends_with(".uid"):
+		if name.ends_with(".uid"):
 			name = dir.get_next()
 			continue
 
-		var full_path := root.path_join(name)
 		if dir.current_is_dir():
 			folders.append(name)
 		else:
@@ -58,95 +62,81 @@ func list_dir(args: Dictionary) -> Dictionary:
 	folders.sort()
 
 	return {
-		"ok": true,
-		"path": root,
-		"files": files,
-		"folders": folders,
-		"total": files.size() + folders.size()
+		&"ok": true,
+		&"path": root,
+		&"files": files,
+		&"folders": folders,
+		&"total": files.size() + folders.size()
 	}
 
 # =============================================================================
 # read_file - Read contents of a file
 # =============================================================================
 func read_file(args: Dictionary) -> Dictionary:
-	var path: String = str(args.get("path", ""))
-	var start_line: int = int(args.get("start_line", 1))
-	var end_line: int = int(args.get("end_line", 0))
-	var max_bytes: int = int(args.get("max_bytes", DEFAULT_MAX_BYTES))
+	var path: String = str(args.get(&"path", ""))
+	var start_line: int = int(args.get(&"start_line", 1))
+	var end_line: int = int(args.get(&"end_line", 0))
+	var max_bytes: int = int(args.get(&"max_bytes", DEFAULT_MAX_BYTES))
 
 	if path.strip_edges().is_empty():
-		return {"ok": false, "error": "Missing 'path' parameter"}
+		return {&"ok": false, &"error": "Missing 'path' parameter"}
 
 	if not path.begins_with("res://"):
 		path = "res://" + path
 
 	if not FileAccess.file_exists(path):
-		return {"ok": false, "error": "File not found: " + path}
+		return {&"ok": false, &"error": "File not found: " + path}
 
 	var file := FileAccess.open(path, FileAccess.READ)
 	if file == null:
-		return {"ok": false, "error": "Cannot open file: " + path}
+		return {&"ok": false, &"error": "Cannot open file: " + path}
 
 	var content: String
 	var line_count: int = 0
 
-	# If no line range specified, read up to max_bytes
-	if end_line <= 0 and start_line <= 1:
-		var size := mini(max_bytes, file.get_length())
-		content = file.get_buffer(size).get_string_from_utf8()
-		# Count lines
-		line_count = content.count("\n") + 1
-	else:
-		# Read specific line range
-		var lines: Array = []
-		var current_line := 0
-		var total_bytes := 0
-
-		while not file.eof_reached():
-			var line := file.get_line()
-			current_line += 1
-
-			if current_line < start_line:
-				continue
-			if end_line > 0 and current_line > end_line:
-				break
-
-			lines.append(line)
-			total_bytes += line.length() + 1  # +1 for newline
-
-			if total_bytes > max_bytes:
-				break
-
-		content = "\n".join(lines)
-		line_count = lines.size()
-
+	# Bulk read — single syscall for any access pattern
+	var file_size := file.get_length()
+	var read_size := mini(max_bytes, file_size)
+	var raw_content := file.get_buffer(read_size).get_string_from_utf8()
 	file.close()
 
+	if end_line <= 0 and start_line <= 1:
+		content = raw_content
+		line_count = content.count("\n") + 1
+	else:
+		# Slice the requested line range from the bulk-read content
+		var all_lines := raw_content.split("\n")
+		var from := maxi(start_line - 1, 0)
+		var to := all_lines.size() if end_line <= 0 else mini(end_line, all_lines.size())
+		var sliced := all_lines.slice(from, to)
+		content = "\n".join(sliced)
+		line_count = sliced.size()
+
 	return {
-		"ok": true,
-		"path": path,
-		"content": content,
-		"line_count": line_count,
-		"range": [start_line, end_line] if end_line > 0 else null
+		&"ok": true,
+		&"path": path,
+		&"content": content,
+		&"line_count": line_count,
+		&"range": [start_line, end_line] if end_line > 0 else null
 	}
 
 # =============================================================================
 # search_project - Search for text in project files
 # =============================================================================
 func search_project(args: Dictionary) -> Dictionary:
-	var query: String = str(args.get("query", ""))
-	var glob_filter: String = str(args.get("glob", ""))
-	var max_results: int = int(args.get("max_results", DEFAULT_MAX_RESULTS))
-	var case_sensitive: bool = bool(args.get("case_sensitive", false))
+	var query: String = str(args.get(&"query", ""))
+	var glob_filter: String = str(args.get(&"glob", ""))
+	var max_results: int = int(args.get(&"max_results", DEFAULT_MAX_RESULTS))
+	var case_sensitive: bool = bool(args.get(&"case_sensitive", false))
 
 	if query.strip_edges().is_empty():
-		return {"ok": false, "error": "Missing 'query' parameter"}
+		return {&"ok": false, &"error": "Missing 'query' parameter"}
 
 	var search_query := query if case_sensitive else query.to_lower()
 	var files := _collect_files("res://", glob_filter)
 	var matches: Array = []
 
-	for file_path in files:
+	for file_path: String in files:
 		if matches.size() >= max_results:
 			break
 
@@ -154,69 +144,70 @@ func search_project(args: Dictionary) -> Dictionary:
 		if file == null:
 			continue
 
-		var line_num := 0
-		while not file.eof_reached():
-			var line := file.get_line()
-			line_num += 1
+		# Bulk read — single syscall instead of one per line
+		var content := file.get_as_text()
+		file.close()
 
+		# Quick whole-file check to skip non-matching files entirely
+		var search_content := content if case_sensitive else content.to_lower()
+		if search_content.find(search_query) == -1:
+			continue
+
+		# Only split files that actually contain the query
+		var lines := content.split("\n")
+		for i: int in range(lines.size()):
+			var line := lines[i]
 			var search_line := line if case_sensitive else line.to_lower()
 			if search_line.find(search_query) != -1:
 				matches.append({
-					"file": file_path,
-					"line": line_num,
-					"content": line.strip_edges()
+					&"file": file_path,
+					&"line": i + 1,
+					&"content": line.strip_edges()
 				})
-
 				if matches.size() >= max_results:
 					break
 
-		file.close()
-
 	return {
-		"ok": true,
-		"query": query,
-		"matches": matches,
-		"total_matches": matches.size(),
-		"truncated": matches.size() >= max_results
+		&"ok": true,
+		&"query": query,
+		&"matches": matches,
+		&"total_matches": matches.size(),
+		&"truncated": matches.size() >= max_results
 	}
 
-func _collect_files(path: String, glob_filter: String) -> Array:
+func _collect_files(path: String, glob_filter: String) -> PackedStringArray:
 	"""Recursively collect all searchable files."""
-	var result: Array = []
+	var result: PackedStringArray = []
 	_collect_files_recursive(path, glob_filter, result)
 	return result
 
-func _collect_files_recursive(path: String, glob_filter: String, out: Array) -> void:
+func _collect_files_recursive(path: String, glob_filter: String, out: PackedStringArray, depth: int = 0) -> void:
+	if depth >= MAX_TRAVERSAL_DEPTH:
+		return
 	var dir := DirAccess.open(path)
 	if dir == null:
 		return
 
 	dir.list_dir_begin()
-	var name := dir.get_next()
-	while name != "":
+	var file_name := dir.get_next()
+	while file_name != "":
 		# Skip hidden
-		if name.begins_with("."):
-			name = dir.get_next()
+		if file_name.begins_with("."):
+			file_name = dir.get_next()
 			continue
 
-		var full_path := path.path_join(name)
+		var full_path := path.path_join(file_name)
 
 		if dir.current_is_dir():
-			_collect_files_recursive(full_path, glob_filter, out)
+			_collect_files_recursive(full_path, glob_filter, out, depth + 1)
 		else:
-			# Skip binary files
-			var skip := false
-			for ext in SKIP_EXTENSIONS:
-				if name.to_lower().ends_with(ext):
-					skip = true
-					break
-
-			if not skip:
-				# Apply glob filter if specified
+			# Skip binary files — O(1) Dictionary lookup on the extension
+			var ext := "." + file_name.get_extension().to_lower()
+			if not _SKIP_EXTENSIONS.has(ext):
 				if glob_filter.is_empty() or _matches_glob(full_path, glob_filter):
 					out.append(full_path)
 
-		name = dir.get_next()
+		file_name = dir.get_next()
 	dir.list_dir_end()
 
 func _matches_glob(path: String, pattern: String) -> bool:
@@ -237,11 +228,11 @@ func _matches_glob(path: String, pattern: String) -> bool:
 # create_script - Create a new GDScript file
 # =============================================================================
 func create_script(args: Dictionary) -> Dictionary:
-	var path: String = str(args.get("path", ""))
-	var content: String = str(args.get("content", ""))
+	var path: String = str(args.get(&"path", ""))
+	var content: String = str(args.get(&"content", ""))
 
 	if path.strip_edges().is_empty():
-		return {"ok": false, "error": "Missing 'path' parameter"}
+		return {&"ok": false, &"error": "Missing 'path' parameter"}
 
 	if not path.begins_with("res://"):
 		path = "res://" + path
@@ -252,19 +243,19 @@ func create_script(args: Dictionary) -> Dictionary:
 
 	# Check if file already exists
 	if FileAccess.file_exists(path):
-		return {"ok": false, "error": "File already exists: " + path}
+		return {&"ok": false, &"error": "File already exists: " + path}
 
 	# Ensure parent directory exists
 	var dir_path := path.get_base_dir()
 	if not DirAccess.dir_exists_absolute(dir_path):
 		var err := DirAccess.make_dir_recursive_absolute(dir_path)
 		if err != OK:
-			return {"ok": false, "error": "Could not create directory: " + dir_path}
+			return {&"ok": false, &"error": "Could not create directory: " + dir_path}
 
 	# Write file
 	var file := FileAccess.open(path, FileAccess.WRITE)
 	if file == null:
-		return {"ok": false, "error": "Could not create file: " + path}
+		return {&"ok": false, &"error": "Could not create file: " + path}
 
 	file.store_string(content)
 	file.close()
@@ -273,10 +264,10 @@ func create_script(args: Dictionary) -> Dictionary:
 	_refresh_filesystem()
 
 	return {
-		"ok": true,
-		"path": path,
-		"size_bytes": content.length(),
-		"message": "Script created successfully"
+		&"ok": true,
+		&"path": path,
+		&"size_bytes": content.length(),
+		&"message": "Script created successfully"
 	}
 
 func _refresh_filesystem() -> void:

--- a/addons/godot_mcp/tools/project_tools.gd
+++ b/addons/godot_mcp/tools/project_tools.gd
@@ -21,67 +21,67 @@ func set_editor_plugin(plugin: EditorPlugin) -> void:
 # get_project_settings
 # =============================================================================
 func get_project_settings(args: Dictionary) -> Dictionary:
-	var include_render: bool = bool(args.get("include_render", true))
-	var include_physics: bool = bool(args.get("include_physics", true))
+	var include_render: bool = bool(args.get(&"include_render", true))
+	var include_physics: bool = bool(args.get(&"include_physics", true))
 
 	var out: Dictionary = {}
-	out["main_scene"] = str(ProjectSettings.get_setting("application/run/main_scene", ""))
+	out[&"main_scene"] = str(ProjectSettings.get_setting("application/run/main_scene", ""))
 
 	# Window size
 	var width = ProjectSettings.get_setting("display/window/size/viewport_width", null)
 	var height = ProjectSettings.get_setting("display/window/size/viewport_height", null)
-	if width != null: out["window_width"] = int(width)
-	if height != null: out["window_height"] = int(height)
+	if width != null: out[&"window_width"] = int(width)
+	if height != null: out[&"window_height"] = int(height)
 
 	# Stretch
 	var stretch_mode = ProjectSettings.get_setting("display/window/stretch/mode", null)
 	var stretch_aspect = ProjectSettings.get_setting("display/window/stretch/aspect", null)
-	if stretch_mode != null: out["stretch_mode"] = str(stretch_mode)
-	if stretch_aspect != null: out["stretch_aspect"] = str(stretch_aspect)
+	if stretch_mode != null: out[&"stretch_mode"] = str(stretch_mode)
+	if stretch_aspect != null: out[&"stretch_aspect"] = str(stretch_aspect)
 
 	if include_physics:
 		var pps = ProjectSettings.get_setting("physics/common/physics_ticks_per_second", null)
-		if pps != null: out["physics_ticks_per_second"] = int(pps)
+		if pps != null: out[&"physics_ticks_per_second"] = int(pps)
 
 	if include_render:
 		var method = ProjectSettings.get_setting("rendering/renderer/rendering_method", null)
-		if method != null: out["rendering_method"] = str(method)
+		if method != null: out[&"rendering_method"] = str(method)
 		var vsync = ProjectSettings.get_setting("display/window/vsync/vsync_mode", null)
-		if vsync != null: out["vsync"] = str(vsync)
+		if vsync != null: out[&"vsync"] = str(vsync)
 
-	return {"ok": true, "settings": out}
+	return {&"ok": true, &"settings": out}
 
 # =============================================================================
 # get_input_map
 # =============================================================================
 func get_input_map(args: Dictionary) -> Dictionary:
-	var include_deadzones: bool = bool(args.get("include_deadzones", true))
+	var include_deadzones: bool = bool(args.get(&"include_deadzones", true))
 	var actions: Array = InputMap.get_actions()
 	actions.sort()
 
 	var result: Dictionary = {}
-	for action in actions:
+	for action: StringName in actions:
 		var events: Array = []
-		for e in InputMap.action_get_events(action):
-			var item := {"type": e.get_class()}
+		for e: InputEvent in InputMap.action_get_events(action):
+			var item := {&"type": e.get_class()}
 
 			if e is InputEventKey:
 				var keycode = e.physical_keycode if e.physical_keycode != 0 else e.keycode
-				item["keycode"] = keycode
-				item["key_label"] = OS.get_keycode_string(keycode) if keycode != 0 else ""
+				item[&"keycode"] = keycode
+				item[&"key_label"] = OS.get_keycode_string(keycode) if keycode != 0 else ""
 			elif e is InputEventMouseButton:
-				item["button_index"] = e.button_index
+				item[&"button_index"] = e.button_index
 			elif e is InputEventJoypadButton:
-				item["button_index"] = e.button_index
+				item[&"button_index"] = e.button_index
 			elif e is InputEventJoypadMotion:
-				item["axis"] = e.axis
+				item[&"axis"] = e.axis
 				if include_deadzones:
-					item["axis_value"] = e.axis_value
+					item[&"axis_value"] = e.axis_value
 
 			events.append(item)
 		result[action] = events
 
-	return {"ok": true, "actions": result, "count": result.size()}
+	return {&"ok": true, &"actions": result, &"count": result.size()}
 
 # =============================================================================
 # get_collision_layers
@@ -89,20 +89,24 @@ func get_input_map(args: Dictionary) -> Dictionary:
 func get_collision_layers(_args: Dictionary) -> Dictionary:
 	var layers_2d: Array = _collect_layers("layer_names/2d_physics")
 	var layers_3d: Array = _collect_layers("layer_names/3d_physics")
-	return {"ok": true, "layers_2d": layers_2d, "layers_3d": layers_3d}
+	return {&"ok": true, &"layers_2d": layers_2d, &"layers_3d": layers_3d}
 
 func _collect_layers(prefix: String) -> Array:
 	var out: Array = []
-	for i in range(1, 33):
+	for i: int in range(1, 33):
 		var key := "%s/layer_%d" % [prefix, i]
 		var layer_name := str(ProjectSettings.get_setting(key, ""))
 		if not layer_name.is_empty():
-			out.append({"index": i, "name": layer_name})
+			out.append({&"index": i, &"name": layer_name})
 	return out
 
 # =============================================================================
 # get_node_properties
 # =============================================================================
+const _SKIP_PROPS: Dictionary = {
+	"script": true, "owner": true, "scene_file_path": true, "unique_name_in_owner": true,
+}
+
 const ENUM_HINTS = {
 	"anchors_preset": "0:Top Left,1:Top Right,2:Bottom Right,3:Bottom Left,4:Center Left,5:Center Top,6:Center Right,7:Center Bottom,8:Center,9:Left Wide,10:Top Wide,11:Right Wide,12:Bottom Wide,13:VCenter Wide,14:HCenter Wide,15:Full Rect",
 	"grow_horizontal": "0:Begin,1:End,2:Both",
@@ -112,37 +116,37 @@ const ENUM_HINTS = {
 }
 
 func get_node_properties(args: Dictionary) -> Dictionary:
-	var node_type: String = str(args.get("node_type", ""))
+	var node_type: String = str(args.get(&"node_type", ""))
 	if node_type.strip_edges().is_empty():
-		return {"ok": false, "error": "Missing 'node_type'"}
+		return {&"ok": false, &"error": "Missing 'node_type'"}
 	if not ClassDB.class_exists(node_type):
-		return {"ok": false, "error": "Unknown node type: " + node_type}
+		return {&"ok": false, &"error": "Unknown node type: " + node_type}
 
 	var temp = ClassDB.instantiate(node_type)
 	if not temp:
-		return {"ok": false, "error": "Cannot instantiate: " + node_type}
+		return {&"ok": false, &"error": "Cannot instantiate: " + node_type}
 
 	var properties: Array = []
-	for prop in temp.get_property_list():
-		var prop_name: String = prop["name"]
+	for prop: Dictionary in temp.get_property_list():
+		var prop_name: String = prop[&"name"]
 		if prop_name.begins_with("_"):
 			continue
-		if prop_name in ["script", "owner", "scene_file_path", "unique_name_in_owner"]:
+		if _SKIP_PROPS.has(prop_name):
 			continue
-		if not (prop.get("usage", 0) & PROPERTY_USAGE_EDITOR):
+		if not (prop.get(&"usage", 0) & PROPERTY_USAGE_EDITOR):
 			continue
 
 		var info := {
-			"name": prop_name,
-			"type": _type_to_string(prop["type"]),
-			"default": _serialize_value(temp.get(prop_name))
+			&"name": prop_name,
+			&"type": _type_to_string(prop[&"type"]),
+			&"default": _serialize_value(temp.get(prop_name))
 		}
 
 		# Enum hints
-		if prop.has("hint") and prop["hint"] == PROPERTY_HINT_ENUM and prop.has("hint_string"):
-			info["enum_values"] = prop["hint_string"]
+		if prop.has(&"hint") and prop[&"hint"] == PROPERTY_HINT_ENUM and prop.has(&"hint_string"):
+			info[&"enum_values"] = prop[&"hint_string"]
 		if prop_name in ENUM_HINTS:
-			info["enum_values"] = ENUM_HINTS[prop_name]
+			info[&"enum_values"] = ENUM_HINTS[prop_name]
 
 		properties.append(info)
 
@@ -155,8 +159,8 @@ func get_node_properties(args: Dictionary) -> Dictionary:
 		chain.append(cls)
 		cls = ClassDB.get_parent_class(cls)
 
-	return {"ok": true, "node_type": node_type, "inheritance_chain": chain,
-		"property_count": properties.size(), "properties": properties}
+	return {&"ok": true, &"node_type": node_type, &"inheritance_chain": chain,
+		&"property_count": properties.size(), &"properties": properties}
 
 func _type_to_string(type_id: int) -> String:
 	match type_id:
@@ -175,16 +179,16 @@ func _type_to_string(type_id: int) -> String:
 		TYPE_DICTIONARY: return "Dictionary"
 		_: return "Variant"
 
-func _serialize_value(value) -> Variant:
+func _serialize_value(value: Variant) -> Variant:
 	match typeof(value):
-		TYPE_VECTOR2: return {"type": "Vector2", "x": value.x, "y": value.y}
-		TYPE_VECTOR3: return {"type": "Vector3", "x": value.x, "y": value.y, "z": value.z}
-		TYPE_COLOR: return {"type": "Color", "r": value.r, "g": value.g, "b": value.b, "a": value.a}
-		TYPE_VECTOR2I: return {"type": "Vector2i", "x": value.x, "y": value.y}
-		TYPE_VECTOR3I: return {"type": "Vector3i", "x": value.x, "y": value.y, "z": value.z}
+		TYPE_VECTOR2: return {&"type": &"Vector2", &"x": value.x, &"y": value.y}
+		TYPE_VECTOR3: return {&"type": &"Vector3", &"x": value.x, &"y": value.y, &"z": value.z}
+		TYPE_COLOR: return {&"type": &"Color", &"r": value.r, &"g": value.g, &"b": value.b, &"a": value.a}
+		TYPE_VECTOR2I: return {&"type": &"Vector2i", &"x": value.x, &"y": value.y}
+		TYPE_VECTOR3I: return {&"type": &"Vector3i", &"x": value.x, &"y": value.y, &"z": value.z}
 		TYPE_OBJECT:
 			if value and value is Resource and value.resource_path:
-				return {"type": "Resource", "path": value.resource_path}
+				return {&"type": &"Resource", &"path": value.resource_path}
 			return null
 		_: return value
 
@@ -210,14 +214,14 @@ func _get_editor_log_rtl() -> RichTextLabel:
 func _find_node_by_class(root: Node, cls_name: String) -> Node:
 	if root.get_class() == cls_name:
 		return root
-	for child in root.get_children():
+	for child: Node in root.get_children():
 		var found := _find_node_by_class(child, cls_name)
 		if found:
 			return found
 	return null
 
 func _find_child_rtl(node: Node) -> RichTextLabel:
-	for child in node.get_children():
+	for child: Node in node.get_children():
 		if child is RichTextLabel:
 			return child
 		var found := _find_child_rtl(child)
@@ -236,7 +240,7 @@ func _read_output_panel_lines() -> Array:
 	elif _clear_char_offset >= full_text.length():
 		return []
 	var lines: Array = []
-	for line in full_text.split("\n"):
+	for line: String in full_text.split("\n"):
 		if not line.strip_edges().is_empty():
 			lines.append(line)
 	return lines
@@ -245,18 +249,18 @@ func _read_output_panel_lines() -> Array:
 # get_console_log
 # =============================================================================
 func get_console_log(args: Dictionary) -> Dictionary:
-	var max_lines: int = int(args.get("max_lines", 50))
+	var max_lines: int = int(args.get(&"max_lines", 50))
 
 	var rtl := _get_editor_log_rtl()
 	if not rtl:
-		return {"ok": false,
-			"error": "Could not access the Godot editor Output panel. Make sure the MCP plugin is enabled and running inside the Godot editor."}
+		return {&"ok": false,
+			&"error": "Could not access the Godot editor Output panel. Make sure the MCP plugin is enabled and running inside the Godot editor."}
 
 	var all_lines := _read_output_panel_lines()
 	var start := maxi(0, all_lines.size() - max_lines)
 	var lines := all_lines.slice(start)
-	return {"ok": true, "lines": lines, "line_count": lines.size(),
-		"content": "\n".join(lines)}
+	return {&"ok": true, &"lines": lines, &"line_count": lines.size(),
+		&"content": "\n".join(lines)}
 
 # =============================================================================
 # get_errors
@@ -268,25 +272,25 @@ const _ERROR_PREFIXES: PackedStringArray = [
 ]
 
 func get_errors(args: Dictionary) -> Dictionary:
-	var max_errors: int = int(args.get("max_errors", 50))
-	var include_warnings: bool = bool(args.get("include_warnings", true))
+	var max_errors: int = int(args.get(&"max_errors", 50))
+	var include_warnings: bool = bool(args.get(&"include_warnings", true))
 
 	var rtl := _get_editor_log_rtl()
 	if not rtl:
-		return {"ok": false,
-			"error": "Could not access the Godot editor Output panel. Make sure the MCP plugin is enabled and running inside the Godot editor."}
+		return {&"ok": false,
+			&"error": "Could not access the Godot editor Output panel. Make sure the MCP plugin is enabled and running inside the Godot editor."}
 
 	var all_lines := _read_output_panel_lines()
 
 	var all_errors: Array = []
-	for i in range(all_lines.size()):
+	for i: int in range(all_lines.size()):
 		var line: String = all_lines[i].strip_edges()
 		if line.is_empty():
 			continue
 
 		var is_error := false
 		var severity := "error"
-		for prefix in _ERROR_PREFIXES:
+		for prefix: String in _ERROR_PREFIXES:
 			if line.begins_with(prefix):
 				is_error = true
 				if "WARNING" in prefix:
@@ -299,8 +303,8 @@ func get_errors(args: Dictionary) -> Dictionary:
 				var prev: Dictionary = all_errors[all_errors.size() - 1]
 				var loc := _extract_file_line(line)
 				if not loc.is_empty():
-					prev["file"] = loc.get("file", "")
-					prev["line"] = loc.get("line", 0)
+					prev[&"file"] = loc.get(&"file", "")
+					prev[&"line"] = loc.get(&"line", 0)
 			continue
 
 		if not is_error:
@@ -308,18 +312,18 @@ func get_errors(args: Dictionary) -> Dictionary:
 		if severity == "warning" and not include_warnings:
 			continue
 
-		var error_info := {"message": line, "severity": severity}
+		var error_info := {&"message": line, &"severity": severity}
 		var loc := _extract_file_line(line)
 		if not loc.is_empty():
-			error_info["file"] = loc.get("file", "")
-			error_info["line"] = loc.get("line", 0)
+			error_info[&"file"] = loc.get(&"file", "")
+			error_info[&"line"] = loc.get(&"line", 0)
 		all_errors.append(error_info)
 
 	# Return the most recent errors
 	var start := maxi(0, all_errors.size() - max_errors)
 	var errors := all_errors.slice(start)
-	return {"ok": true, "errors": errors, "error_count": errors.size(),
-		"summary": "%d error(s) found" % errors.size()}
+	return {&"ok": true, &"errors": errors, &"error_count": errors.size(),
+		&"summary": "%d error(s) found" % errors.size()}
 
 func _extract_file_line(text: String) -> Dictionary:
 	var idx := text.find("res://")
@@ -328,18 +332,18 @@ func _extract_file_line(text: String) -> Dictionary:
 	var rest := text.substr(idx)
 	var colon_idx := rest.find(":", 6)
 	if colon_idx == -1:
-		return {"file": rest.strip_edges()}
+		return {&"file": rest.strip_edges()}
 	var file_path := rest.substr(0, colon_idx)
 	var after_colon := rest.substr(colon_idx + 1)
-	var line_str := ""
-	for c in after_colon:
+	var digits: PackedStringArray = []
+	for c: String in after_colon:
 		if c.is_valid_int():
-			line_str += c
+			digits.append(c)
 		else:
 			break
-	if not line_str.is_empty():
-		return {"file": file_path, "line": int(line_str)}
-	return {"file": file_path}
+	if not digits.is_empty():
+		return {&"file": file_path, &"line": int("".join(digits))}
+	return {&"file": file_path}
 
 # =============================================================================
 # clear_console_log
@@ -347,30 +351,30 @@ func _extract_file_line(text: String) -> Dictionary:
 func clear_console_log(_args: Dictionary) -> Dictionary:
 	var rtl := _get_editor_log_rtl()
 	if not rtl:
-		return {"ok": false,
-			"error": "Could not access the Godot editor Output panel. Make sure the MCP plugin is enabled and running inside the Godot editor."}
+		return {&"ok": false,
+			&"error": "Could not access the Godot editor Output panel. Make sure the MCP plugin is enabled and running inside the Godot editor."}
 
 	# Actually clear the editor Output panel
 	rtl.clear()
 	_clear_char_offset = 0
-	return {"ok": true,
-		"message": "Console log cleared."}
+	return {&"ok": true,
+		&"message": "Console log cleared."}
 
 # =============================================================================
 # open_in_godot
 # =============================================================================
 func open_in_godot(args: Dictionary) -> Dictionary:
-	var path: String = str(args.get("path", ""))
-	var line: int = int(args.get("line", 0))
+	var path: String = str(args.get(&"path", ""))
+	var line: int = int(args.get(&"line", 0))
 
 	if path.strip_edges().is_empty():
-		return {"ok": false, "error": "Missing 'path'"}
+		return {&"ok": false, &"error": "Missing 'path'"}
 
 	if not path.begins_with("res://"):
 		path = "res://" + path
 
 	if not _editor_plugin:
-		return {"ok": false, "error": "Editor plugin not available"}
+		return {&"ok": false, &"error": "Editor plugin not available"}
 
 	var ei = _editor_plugin.get_editor_interface()
 
@@ -381,7 +385,7 @@ func open_in_godot(args: Dictionary) -> Dictionary:
 			if line > 0:
 				ei.get_script_editor().goto_line(line - 1)
 		else:
-			return {"ok": false, "error": "Could not load: " + path}
+			return {&"ok": false, &"error": "Could not load: " + path}
 	elif path.ends_with(".tscn") or path.ends_with(".scn"):
 		ei.open_scene_from_path(path)
 	else:
@@ -389,24 +393,24 @@ func open_in_godot(args: Dictionary) -> Dictionary:
 		if res:
 			ei.edit_resource(res)
 
-	return {"ok": true, "message": "Opened %s%s" % [path, " at line %d" % line if line > 0 else ""]}
+	return {&"ok": true, &"message": "Opened %s%s" % [path, " at line %d" % line if line > 0 else ""]}
 
 # =============================================================================
 # scene_tree_dump
 # =============================================================================
 func scene_tree_dump(_args: Dictionary) -> Dictionary:
 	if not _editor_plugin:
-		return {"ok": false, "error": "Editor plugin not available"}
+		return {&"ok": false, &"error": "Editor plugin not available"}
 
 	var ei = _editor_plugin.get_editor_interface()
 	var edited_scene = ei.get_edited_scene_root()
 
 	if not edited_scene:
-		return {"ok": true, "tree": "(no scene open)", "message": "No scene is currently open in the editor"}
+		return {&"ok": true, &"tree": "(no scene open)", &"message": "No scene is currently open in the editor"}
 
 	var tree_text := _dump_node(edited_scene, 0)
 
-	return {"ok": true, "tree": tree_text, "scene_path": edited_scene.scene_file_path}
+	return {&"ok": true, &"tree": tree_text, &"scene_path": edited_scene.scene_file_path}
 
 func _dump_node(node: Node, depth: int) -> String:
 	var indent := "  ".repeat(depth)
@@ -416,7 +420,11 @@ func _dump_node(node: Node, depth: int) -> String:
 	if script:
 		line += " [%s]" % script.resource_path.get_file()
 
-	var result := line
-	for child in node.get_children():
-		result += "\n" + _dump_node(child, depth + 1)
-	return result
+	var children := node.get_children()
+	if children.is_empty():
+		return line
+
+	var parts: PackedStringArray = [line]
+	for child: Node in children:
+		parts.append(_dump_node(child, depth + 1))
+	return "\n".join(parts)

--- a/addons/godot_mcp/tools/script_tools.gd
+++ b/addons/godot_mcp/tools/script_tools.gd
@@ -23,35 +23,35 @@ func _ensure_res_path(path: String) -> String:
 # edit_script - Apply a small surgical code edit to a GDScript file
 # =============================================================================
 func edit_script(args: Dictionary) -> Dictionary:
-	var edit: Dictionary = args.get("edit", {})
+	var edit: Dictionary = args.get(&"edit", {})
 	if edit.is_empty():
-		return {"ok": false, "error": "Missing 'edit' payload"}
+		return {&"ok": false, &"error": "Missing 'edit' payload"}
 
-	var path: String = str(edit.get("file", ""))
+	var path: String = str(edit.get(&"file", ""))
 	if path.is_empty():
-		return {"ok": false, "error": "Missing 'file' in edit"}
+		return {&"ok": false, &"error": "Missing 'file' in edit"}
 
 	path = _ensure_res_path(path)
 
 	if not FileAccess.file_exists(path):
-		return {"ok": false, "error": "File not found: " + path}
+		return {&"ok": false, &"error": "File not found: " + path}
 
-	var spec_type: String = str(edit.get("type", "snippet_replace"))
+	var spec_type: String = str(edit.get(&"type", "snippet_replace"))
 	if spec_type != "snippet_replace":
-		return {"ok": false, "error": "Only 'snippet_replace' type is supported"}
+		return {&"ok": false, &"error": "Only 'snippet_replace' type is supported"}
 
-	var old_snippet: String = str(edit.get("old_snippet", ""))
-	var new_snippet: String = str(edit.get("new_snippet", ""))
-	var context_before: String = str(edit.get("context_before", ""))
-	var context_after: String = str(edit.get("context_after", ""))
+	var old_snippet: String = str(edit.get(&"old_snippet", ""))
+	var new_snippet: String = str(edit.get(&"new_snippet", ""))
+	var context_before: String = str(edit.get(&"context_before", ""))
+	var context_after: String = str(edit.get(&"context_after", ""))
 
 	if old_snippet.is_empty():
-		return {"ok": false, "error": "Missing 'old_snippet' in edit"}
+		return {&"ok": false, &"error": "Missing 'old_snippet' in edit"}
 
 	# Read current file content
 	var file := FileAccess.open(path, FileAccess.READ)
 	if not file:
-		return {"ok": false, "error": "Cannot read file: " + path}
+		return {&"ok": false, &"error": "Cannot read file: " + path}
 	var content := file.get_as_text()
 	file.close()
 
@@ -70,21 +70,20 @@ func edit_script(args: Dictionary) -> Dictionary:
 				pos = after_ctx + snippet_pos
 
 	if pos == -1:
-		return {"ok": false, "error": "Could not find old_snippet in file. Make sure old_snippet matches the file content exactly."}
+		return {&"ok": false, &"error": "Could not find old_snippet in file. Make sure old_snippet matches the file content exactly."}
 
 	# Check for multiple occurrences
 	var second_pos := content.find(search_text, pos + 1)
 	if second_pos != -1 and context_before.is_empty() and context_after.is_empty():
-		return {"ok": false, "error": "old_snippet appears multiple times. Add context_before or context_after for disambiguation."}
+		return {&"ok": false, &"error": "old_snippet appears multiple times. Add context_before or context_after for disambiguation."}
 
 	# Apply the replacement
-	var original_content := content
 	var new_content := content.substr(0, pos) + new_snippet + content.substr(pos + old_snippet.length())
 
 	# Write back
 	file = FileAccess.open(path, FileAccess.WRITE)
 	if not file:
-		return {"ok": false, "error": "Cannot write file: " + path}
+		return {&"ok": false, &"error": "Cannot write file: " + path}
 	file.store_string(new_content)
 	file.close()
 
@@ -97,32 +96,32 @@ func edit_script(args: Dictionary) -> Dictionary:
 	_refresh_filesystem()
 
 	return {
-		"ok": true,
-		"path": path,
-		"added": added,
-		"removed": removed,
-		"auto_applied": true,
-		"message": "Applied edit to %s (+%d -%d lines)" % [path, added, removed]
+		&"ok": true,
+		&"path": path,
+		&"added": added,
+		&"removed": removed,
+		&"auto_applied": true,
+		&"message": "Applied edit to %s (+%d -%d lines)" % [path, added, removed]
 	}
 
 # =============================================================================
 # validate_script
 # =============================================================================
 func validate_script(args: Dictionary) -> Dictionary:
-	var path: String = str(args.get("path", ""))
+	var path: String = str(args.get(&"path", ""))
 	if path.strip_edges().is_empty():
-		return {"ok": false, "error": "Missing 'path'"}
+		return {&"ok": false, &"error": "Missing 'path'"}
 
 	path = _ensure_res_path(path)
 
 	if not FileAccess.file_exists(path):
-		return {"ok": false, "error": "File not found: " + path}
+		return {&"ok": false, &"error": "File not found: " + path}
 
 	# Read the source text directly from disk so we validate the *current*
 	# file contents, not a stale resource-cache entry.
 	var file := FileAccess.open(path, FileAccess.READ)
 	if not file:
-		return {"ok": false, "error": "Cannot read file: " + path}
+		return {&"ok": false, &"error": "Cannot read file: " + path}
 	var source_code := file.get_as_text()
 	file.close()
 
@@ -137,27 +136,27 @@ func validate_script(args: Dictionary) -> Dictionary:
 		# Try to extract useful details from the Godot output log.
 		var errors := _collect_recent_script_errors(path)
 		return {
-			"ok": true,
-			"valid": false,
-			"path": path,
-			"error_code": err,
-			"errors": errors,
-			"message": "Script has errors." + (" Details: " + "; ".join(errors) if errors.size() > 0 else " Check Godot console for details.")
+			&"ok": true,
+			&"valid": false,
+			&"path": path,
+			&"error_code": err,
+			&"errors": errors,
+			&"message": "Script has errors." + (" Details: " + "; ".join(errors) if errors.size() > 0 else " Check Godot console for details.")
 		}
 
 	if not script.can_instantiate():
 		return {
-			"ok": true,
-			"valid": false,
-			"path": path,
-			"message": "Script parsed but cannot be instantiated (may have dependency errors)"
+			&"ok": true,
+			&"valid": false,
+			&"path": path,
+			&"message": "Script parsed but cannot be instantiated (may have dependency errors)"
 		}
 
 	return {
-		"ok": true,
-		"valid": true,
-		"path": path,
-		"message": "No syntax errors found"
+		&"ok": true,
+		&"valid": true,
+		&"path": path,
+		&"message": "No syntax errors found"
 	}
 
 func _collect_recent_script_errors(script_path: String) -> Array:
@@ -180,7 +179,7 @@ func _collect_recent_script_errors(script_path: String) -> Array:
 	var text: String = rtl.get_parsed_text()
 	var short_path := script_path.get_file()  # e.g. "player.gd"
 
-	for line in text.split("\n"):
+	for line: String in text.split("\n"):
 		line = line.strip_edges()
 		if line.is_empty():
 			continue
@@ -197,14 +196,14 @@ func _collect_recent_script_errors(script_path: String) -> Array:
 func _find_node_by_class(root: Node, cls_name: String) -> Node:
 	if root.get_class() == cls_name:
 		return root
-	for child in root.get_children():
+	for child: Node in root.get_children():
 		var found := _find_node_by_class(child, cls_name)
 		if found:
 			return found
 	return null
 
 func _find_child_rtl(node: Node) -> RichTextLabel:
-	for child in node.get_children():
+	for child: Node in node.get_children():
 		if child is RichTextLabel:
 			return child
 		var found := _find_child_rtl(child)
@@ -216,74 +215,78 @@ func _find_child_rtl(node: Node) -> RichTextLabel:
 # list_scripts
 # =============================================================================
 func list_scripts(args: Dictionary) -> Dictionary:
-	var scripts: Array = []
+	var scripts: PackedStringArray = []
 	_collect_scripts("res://", scripts)
 
 	return {
-		"ok": true,
-		"scripts": scripts,
-		"count": scripts.size()
+		&"ok": true,
+		&"scripts": scripts,
+		&"count": scripts.size()
 	}
 
-func _collect_scripts(path: String, out: Array) -> void:
+const MAX_TRAVERSAL_DEPTH := 20
+
+func _collect_scripts(path: String, out: PackedStringArray, depth: int = 0) -> void:
+	if depth >= MAX_TRAVERSAL_DEPTH:
+		return
 	var dir := DirAccess.open(path)
 	if dir == null:
 		return
 
 	dir.list_dir_begin()
-	var name := dir.get_next()
-	while name != "":
-		if name.begins_with("."):
-			name = dir.get_next()
+	var file_name := dir.get_next()
+	while file_name != "":
+		if file_name.begins_with("."):
+			file_name = dir.get_next()
 			continue
 
-		var full_path := path.path_join(name)
+		var full_path := path.path_join(file_name)
 		if dir.current_is_dir():
-			_collect_scripts(full_path, out)
-		elif name.ends_with(".gd"):
+			_collect_scripts(full_path, out, depth + 1)
+		elif file_name.ends_with(".gd"):
 			out.append(full_path)
 
-		name = dir.get_next()
+		file_name = dir.get_next()
 	dir.list_dir_end()
 
 # =============================================================================
 # create_folder
 # =============================================================================
 func create_folder(args: Dictionary) -> Dictionary:
-	var path: String = str(args.get("path", ""))
+	var path: String = str(args.get(&"path", ""))
 	if path.strip_edges().is_empty():
-		return {"ok": false, "error": "Missing 'path'"}
+		return {&"ok": false, &"error": "Missing 'path'"}
 
 	path = _ensure_res_path(path)
 
 	if DirAccess.dir_exists_absolute(path):
-		return {"ok": true, "path": path, "message": "Directory already exists"}
+		return {&"ok": true, &"path": path, &"message": "Directory already exists"}
 
 	var err := DirAccess.make_dir_recursive_absolute(path)
 	if err != OK:
-		return {"ok": false, "error": "Failed to create directory: " + str(err)}
+		return {&"ok": false, &"error": "Failed to create directory: " + str(err)}
 
 	_refresh_filesystem()
 
-	return {"ok": true, "path": path, "message": "Directory created"}
+	return {&"ok": true, &"path": path, &"message": "Directory created"}
 
 # =============================================================================
 # delete_file
 # =============================================================================
 func delete_file(args: Dictionary) -> Dictionary:
-	var path: String = str(args.get("path", ""))
-	var confirm: bool = bool(args.get("confirm", false))
-	var create_backup: bool = bool(args.get("create_backup", true))
+	var path: String = str(args.get(&"path", ""))
+	var confirm: bool = bool(args.get(&"confirm", false))
+	var create_backup: bool = bool(args.get(&"create_backup", true))
 
 	if path.strip_edges().is_empty():
-		return {"ok": false, "error": "Missing 'path'"}
+		return {&"ok": false, &"error": "Missing 'path'"}
 	if not confirm:
-		return {"ok": false, "error": "Must set confirm=true to delete"}
+		return {&"ok": false, &"error": "Must set confirm=true to delete"}
 
 	path = _ensure_res_path(path)
 
 	if not FileAccess.file_exists(path):
-		return {"ok": false, "error": "File not found: " + path}
+		return {&"ok": false, &"error": "File not found: " + path}
 
 	# Create backup
 	if create_backup:
@@ -292,31 +295,31 @@ func delete_file(args: Dictionary) -> Dictionary:
 
 	var err := DirAccess.remove_absolute(path)
 	if err != OK:
-		return {"ok": false, "error": "Failed to delete file: " + str(err)}
+		return {&"ok": false, &"error": "Failed to delete file: " + str(err)}
 
 	_refresh_filesystem()
 
-	return {"ok": true, "path": path, "message": "File deleted" + (" (backup created)" if create_backup else "")}
+	return {&"ok": true, &"path": path, &"message": "File deleted" + (" (backup created)" if create_backup else "")}
 
 # =============================================================================
 # rename_file
 # =============================================================================
 func rename_file(args: Dictionary) -> Dictionary:
-	var old_path: String = str(args.get("old_path", ""))
-	var new_path: String = str(args.get("new_path", ""))
+	var old_path: String = str(args.get(&"old_path", ""))
+	var new_path: String = str(args.get(&"new_path", ""))
 
 	if old_path.strip_edges().is_empty():
-		return {"ok": false, "error": "Missing 'old_path'"}
+		return {&"ok": false, &"error": "Missing 'old_path'"}
 	if new_path.strip_edges().is_empty():
-		return {"ok": false, "error": "Missing 'new_path'"}
+		return {&"ok": false, &"error": "Missing 'new_path'"}
 
 	old_path = _ensure_res_path(old_path)
 	new_path = _ensure_res_path(new_path)
 
 	if not FileAccess.file_exists(old_path):
-		return {"ok": false, "error": "File not found: " + old_path}
+		return {&"ok": false, &"error": "File not found: " + old_path}
 	if FileAccess.file_exists(new_path):
-		return {"ok": false, "error": "Target already exists: " + new_path}
+		return {&"ok": false, &"error": "Target already exists: " + new_path}
 
 	# Ensure target directory exists
 	var dir_path := new_path.get_base_dir()
@@ -325,9 +328,9 @@ func rename_file(args: Dictionary) -> Dictionary:
 
 	var err := DirAccess.rename_absolute(old_path, new_path)
 	if err != OK:
-		return {"ok": false, "error": "Failed to rename: " + str(err)}
+		return {&"ok": false, &"error": "Failed to rename: " + str(err)}
 
 	_refresh_filesystem()
 
-	return {"ok": true, "old_path": old_path, "new_path": new_path,
-		"message": "Renamed %s to %s" % [old_path, new_path]}
+	return {&"ok": true, &"old_path": old_path, &"new_path": new_path,
+		&"message": "Renamed %s to %s" % [old_path, new_path]}

--- a/addons/godot_mcp/tools/visualizer_tools.gd
+++ b/addons/godot_mcp/tools/visualizer_tools.gd
@@ -6,6 +6,52 @@ class_name VisualizerTools
 var _editor_plugin: EditorPlugin = null
 var _scene_tools_ref: Node = null
 
+# Cached RegEx patterns for _parse_script (compiled once, reused per file)
+var _re_desc: RegEx
+var _re_extends: RegEx
+var _re_class_name: RegEx
+var _re_var: RegEx
+var _re_func: RegEx
+var _re_signal: RegEx
+var _re_preload: RegEx
+var _re_connect_obj: RegEx
+var _re_connect_direct: RegEx
+
+# Cached RegEx patterns for _parse_scene
+var _re_ext_resource: RegEx
+var _re_ext_id: RegEx
+var _re_node: RegEx
+var _re_node_instance: RegEx
+var _re_script_ref: RegEx
+
+# Cached RegEx patterns for helpers
+var _re_helper_var: RegEx
+var _re_helper_func: RegEx
+var _re_helper_class: RegEx
+var _re_helper_signal: RegEx
+
+func _init() -> void:
+	_re_desc = RegEx.create_from_string("^##\\s*@desc:\\s*(.+)")
+	_re_extends = RegEx.create_from_string("^extends\\s+(\\w+)")
+	_re_class_name = RegEx.create_from_string("^class_name\\s+(\\w+)")
+	_re_var = RegEx.create_from_string("^(@export(?:\\([^)]*\\))?\\s+)?(@onready\\s+)?var\\s+(\\w+)\\s*(?::\\s*(\\w+))?(?:\\s*=\\s*(.+))?")
+	_re_func = RegEx.create_from_string("^func\\s+(\\w+)\\s*\\(([^)]*)\\)\\s*(?:->\\s*(\\w+))?")
+	_re_signal = RegEx.create_from_string("^signal\\s+(\\w+)(?:\\(([^)]*)\\))?")
+	_re_preload = RegEx.create_from_string("(?:preload|load)\\s*\\(\\s*\"(res://[^\"]+)\"\\s*\\)")
+	_re_connect_obj = RegEx.create_from_string("(\\w+)\\.(\\w+)\\.connect\\s*\\(")
+	_re_connect_direct = RegEx.create_from_string("^\\s*(\\w+)\\.connect\\s*\\(")
+
+	_re_ext_resource = RegEx.create_from_string('\\[ext_resource.*path="([^"]+)".*type="([^"]+)"')
+	_re_ext_id = RegEx.create_from_string('id="([^"]+)"')
+	_re_node = RegEx.create_from_string('\\[node name="([^"]+)".*type="([^"]+)"')
+	_re_node_instance = RegEx.create_from_string('\\[node name="([^"]+)".*instance=ExtResource\\("([^"]+)"\\)')
+	_re_script_ref = RegEx.create_from_string('script = ExtResource\\("([^"]+)"\\)')
+
+	_re_helper_var = RegEx.create_from_string("^(@export)?\\s*(@onready)?\\s*var\\s+")
+	_re_helper_func = RegEx.create_from_string("^func\\s+")
+	_re_helper_class = RegEx.create_from_string("^(class_name|extends)\\s+")
+	_re_helper_signal = RegEx.create_from_string("^signal\\s+")
+
 func set_editor_plugin(plugin: EditorPlugin) -> void:
 	_editor_plugin = plugin
 
@@ -14,62 +60,66 @@ func set_scene_tools_ref(scene_tools: Node) -> void:
 
 func map_project(args: Dictionary) -> Dictionary:
 	"""Crawl the entire project and build a structural map of all scripts."""
-	var root_path: String = str(args.get("root", "res://"))
-	var include_addons: bool = bool(args.get("include_addons", false))
+	var root_path: String = str(args.get(&"root", "res://"))
+	var include_addons: bool = bool(args.get(&"include_addons", false))
 
 	if not root_path.begins_with("res://"):
 		root_path = "res://" + root_path
 
 	# Collect all .gd files
-	var script_paths: Array = []
+	var script_paths: PackedStringArray = []
 	_collect_scripts(root_path, script_paths, include_addons)
 
 	if script_paths.is_empty():
-		return {"ok": false, "error": "No GDScript files found in " + root_path}
+		return {&"ok": false, &"error": "No GDScript files found in " + root_path}
 
 	# Parse each script
 	var nodes: Array = []
 	var class_map: Dictionary = {}  # class_name -> path
 
-	for path in script_paths:
+	for path: String in script_paths:
 		var info: Dictionary = _parse_script(path)
 		nodes.append(info)
-		if info.get("class_name", "") != "":
-			class_map[info["class_name"]] = path
+		if info.get(&"class_name", "") != "":
+			class_map[info[&"class_name"]] = path
 
 	# Build edges
 	var edges: Array = []
-	for node in nodes:
-		var from_path: String = node["path"]
+	for node: Dictionary in nodes:
+		var from_path: String = node[&"path"]
 
 		# extends relationship (resolve class_name to path)
-		var extends_class: String = node.get("extends", "")
+		var extends_class: String = node.get(&"extends", "")
 		if extends_class in class_map:
-			edges.append({"from": from_path, "to": class_map[extends_class], "type": "extends"})
+			edges.append({&"from": from_path, &"to": class_map[extends_class], &"type": "extends"})
 
 		# preload/load references
-		for ref in node.get("preloads", []):
+		for ref: String in node.get(&"preloads", []):
 			if ref.ends_with(".gd"):
-				edges.append({"from": from_path, "to": ref, "type": "preload"})
+				edges.append({&"from": from_path, &"to": ref, &"type": "preload"})
 
 		# signal connections
-		for conn in node.get("connections", []):
-			var target: String = conn.get("target", "")
+		for conn: Dictionary in node.get(&"connections", []):
+			var target: String = conn.get(&"target", "")
 			if target in class_map:
-				edges.append({"from": from_path, "to": class_map[target], "type": "signal", "signal_name": conn.get("signal", "")})
+				edges.append({&"from": from_path, &"to": class_map[target], &"type": "signal", &"signal_name": conn.get(&"signal", "")})
 
 	return {
-		"ok": true,
-		"project_map": {
-			"nodes": nodes,
-			"edges": edges,
-			"total_scripts": nodes.size(),
-			"total_connections": edges.size()
+		&"ok": true,
+		&"project_map": {
+			&"nodes": nodes,
+			&"edges": edges,
+			&"total_scripts": nodes.size(),
+			&"total_connections": edges.size()
 		}
 	}
 
-func _collect_scripts(path: String, results: Array, include_addons: bool) -> void:
+const MAX_TRAVERSAL_DEPTH := 20
+
+func _collect_scripts(path: String, results: PackedStringArray, include_addons: bool, depth: int = 0) -> void:
 	"""Recursively collect all .gd files."""
+	if depth >= MAX_TRAVERSAL_DEPTH:
+		return
 	var dir := DirAccess.open(path)
 	if dir == null:
 		return
@@ -87,7 +137,7 @@ func _collect_scripts(path: String, results: Array, include_addons: bool) -> voi
 			if name == "addons" and not include_addons:
 				name = dir.get_next()
 				continue
-			_collect_scripts(full_path, results, include_addons)
+			_collect_scripts(full_path, results, include_addons, depth + 1)
 		elif name.ends_with(".gd"):
 			results.append(full_path)
 
@@ -98,7 +148,7 @@ func _parse_script(path: String) -> Dictionary:
 	"""Parse a GDScript file and extract its structure."""
 	var file := FileAccess.open(path, FileAccess.READ)
 	if file == null:
-		return {"path": path, "error": "Cannot open file"}
+		return {&"path": path, &"error": "Cannot open file"}
 
 	var content: String = file.get_as_text()
 	file.close()
@@ -115,67 +165,33 @@ func _parse_script(path: String) -> Dictionary:
 	var preloads: Array = []
 	var connections: Array = []
 
-	# Regex patterns
-	var re_desc := RegEx.new()
-	re_desc.compile("^##\\s*@desc:\\s*(.+)")
-
-	var re_extends := RegEx.new()
-	re_extends.compile("^extends\\s+(\\w+)")
-
-	var re_class_name := RegEx.new()
-	re_class_name.compile("^class_name\\s+(\\w+)")
-
-	# Match: @export var name: Type = value  OR  var name: Type  OR  var name = value
-	# Captures: 1=@export, 2=@onready, 3=name, 4=type, 5=default
-	var re_var := RegEx.new()
-	re_var.compile("^(@export(?:\\([^)]*\\))?\\s+)?(@onready\\s+)?var\\s+(\\w+)\\s*(?::\\s*(\\w+))?(?:\\s*=\\s*(.+))?")
-
-	# Match: func name(params) -> ReturnType:
-	var re_func := RegEx.new()
-	re_func.compile("^func\\s+(\\w+)\\s*\\(([^)]*)\\)\\s*(?:->\\s*(\\w+))?")
-
-	# Match: signal name(params)
-	var re_signal := RegEx.new()
-	re_signal.compile("^signal\\s+(\\w+)(?:\\(([^)]*)\\))?")
-
-	var re_preload := RegEx.new()
-	re_preload.compile("(?:preload|load)\\s*\\(\\s*\"(res://[^\"]+)\"\\s*\\)")
-
-	# Match: obj.signal.connect(...) pattern (Godot 4 style)
-	var re_connect_obj := RegEx.new()
-	re_connect_obj.compile("(\\w+)\\.(\\w+)\\.connect\\s*\\(")
-	
-	# Match: signal.connect(...) pattern (direct signal)
-	var re_connect_direct := RegEx.new()
-	re_connect_direct.compile("^\\s*(\\w+)\\.connect\\s*\\(")
-	
 	# Map of variable names to their types (for resolving signal connections)
 	var var_type_map: Dictionary = {}
 
 	# First pass: extract metadata and find function boundaries
 	var func_starts: Array = []  # [{line_idx, name}]
 
-	for i in range(line_count):
+	for i: int in range(line_count):
 		var line: String = lines[i]
 		var stripped: String = line.strip_edges()
 
 		# Description tag (check first 15 lines)
 		if i < 15 and description.is_empty():
-			var m := re_desc.search(stripped)
+			var m := _re_desc.search(stripped)
 			if m:
 				description = m.get_string(1)
 				continue
 
 		# extends
 		if extends_class.is_empty():
-			var m := re_extends.search(stripped)
+			var m := _re_extends.search(stripped)
 			if m:
 				extends_class = m.get_string(1)
 				continue
 
 		# class_name
 		if class_name_str.is_empty():
-			var m := re_class_name.search(stripped)
+			var m := _re_class_name.search(stripped)
 			if m:
 				class_name_str = m.get_string(1)
 				continue
@@ -183,86 +199,86 @@ func _parse_script(path: String) -> Dictionary:
 		# Variables - only match top-level (not indented)
 		# Skip lines that start with tab or spaces (inside functions)
 		if not line.begins_with("\t") and not line.begins_with(" "):
-			var m_var := re_var.search(stripped)
+			var m_var := _re_var.search(stripped)
 			if m_var:
-				var exported: bool = m_var.get_string(1).strip_edges() != ""
-				var onready: bool = m_var.get_string(2).strip_edges() != ""
+				var exported: bool = m_var.get_string(1) != ""
+				var onready: bool = m_var.get_string(2) != ""
 				var var_name: String = m_var.get_string(3)
-				var var_type: String = m_var.get_string(4).strip_edges()
+				var var_type: String = m_var.get_string(4)
 				var default_val: String = m_var.get_string(5).strip_edges()
 
 				# Try to infer type from default value if no explicit type
 				if var_type.is_empty() and not default_val.is_empty():
 					var_type = _infer_type(default_val)
-				
+
 				# Track variable types for signal connection resolution
 				if not var_type.is_empty():
 					var_type_map[var_name] = var_type
 
 				variables.append({
-					"name": var_name,
-					"type": var_type,
-					"exported": exported,
-					"onready": onready,
-					"default": default_val
+					&"name": var_name,
+					&"type": var_type,
+					&"exported": exported,
+					&"onready": onready,
+					&"default": default_val
 				})
 
 		# Functions
-		var m_func := re_func.search(stripped)
+		var m_func := _re_func.search(stripped)
 		if m_func:
 			var func_name: String = m_func.get_string(1)
-			var return_type: String = m_func.get_string(3).strip_edges()
-			func_starts.append({"line_idx": i, "name": func_name})
+			var return_type: String = m_func.get_string(3)
+			func_starts.append({&"line_idx": i, &"name": func_name})
 			functions.append({
-				"name": func_name,
-				"params": m_func.get_string(2).strip_edges(),
-				"return_type": return_type,
-				"line": i + 1,
-				"body": ""  # filled in second pass
+				&"name": func_name,
+				&"params": m_func.get_string(2).strip_edges(),
+				&"return_type": return_type,
+				&"line": i + 1,
+				&"body": ""  # filled in second pass
 			})
 
 		# Signals
-		var m_sig := re_signal.search(stripped)
+		var m_sig := _re_signal.search(stripped)
 		if m_sig:
 			signals_list.append({
-				"name": m_sig.get_string(1),
-				"params": m_sig.get_string(2).strip_edges() if m_sig.get_string(2) else ""
+				&"name": m_sig.get_string(1),
+				&"params": m_sig.get_string(2).strip_edges() if m_sig.get_string(2) else ""
 			})
 
 		# Preload/load references
-		var m_preload := re_preload.search(stripped)
+		var m_preload := _re_preload.search(stripped)
 		if m_preload:
 			preloads.append(m_preload.get_string(1))
 
 		# Signal connections (Godot 4 style)
 		# Pattern: obj.signal.connect(...) - e.g. wave_manager.wave_started.connect(...)
-		var m_conn_obj := re_connect_obj.search(stripped)
+		var m_conn_obj := _re_connect_obj.search(stripped)
 		if m_conn_obj:
 			var obj_name: String = m_conn_obj.get_string(1)
 			var signal_name: String = m_conn_obj.get_string(2)
 			var target_type: String = var_type_map.get(obj_name, "")
 			connections.append({
-				"object": obj_name,
-				"signal": signal_name,
-				"target": target_type,
-				"line": i + 1
+				&"object": obj_name,
+				&"signal": signal_name,
+				&"target": target_type,
+				&"line": i + 1
 			})
 		else:
 			# Pattern: signal.connect(...) - e.g. body_entered.connect(...)
-			var m_conn_direct := re_connect_direct.search(stripped)
+			var m_conn_direct := _re_connect_direct.search(stripped)
 			if m_conn_direct:
 				connections.append({
-					"signal": m_conn_direct.get_string(1),
-					"target": extends_class,  # Direct signal likely from parent class
-					"line": i + 1
+					&"signal": m_conn_direct.get_string(1),
+					&"target": extends_class,  # Direct signal likely from parent class
+					&"line": i + 1
 				})
 
 	# Second pass: extract function bodies
-	for fi in range(func_starts.size()):
-		var start_idx: int = func_starts[fi]["line_idx"]
+	for fi: int in range(func_starts.size()):
+		var start_idx: int = func_starts[fi][&"line_idx"]
 		var end_idx: int
 		if fi + 1 < func_starts.size():
-			end_idx = func_starts[fi + 1]["line_idx"]
+			end_idx = func_starts[fi + 1][&"line_idx"]
 		else:
 			end_idx = line_count
 
@@ -272,7 +288,7 @@ func _parse_script(path: String) -> Dictionary:
 
 		# Also check for top-level declarations (var, signal, @export, class_name, etc.)
 		# that would end the function body
-		for check_idx in range(start_idx + 1, end_idx):
+		for check_idx: int in range(start_idx + 1, end_idx):
 			var check_line: String = lines[check_idx]
 			# If line is not indented and not empty and not a comment, it's not part of the function
 			if not check_line.is_empty() and not check_line.begins_with("\t") and not check_line.begins_with(" ") and not check_line.begins_with("#"):
@@ -280,7 +296,7 @@ func _parse_script(path: String) -> Dictionary:
 				break
 
 		var body_lines: PackedStringArray = PackedStringArray()
-		for li in range(start_idx, end_idx):
+		for li: int in range(start_idx, end_idx):
 			body_lines.append(lines[li])
 
 		var body: String = "\n".join(body_lines)
@@ -288,26 +304,26 @@ func _parse_script(path: String) -> Dictionary:
 		if body.length() > 3000:
 			body = body.substr(0, 3000) + "\n# ... (truncated)"
 
-		functions[fi]["body"] = body
-		functions[fi]["body_lines"] = end_idx - start_idx
+		functions[fi][&"body"] = body
+		functions[fi][&"body_lines"] = end_idx - start_idx
 
 	# Determine folder
 	var folder: String = path.get_base_dir()
 	var filename: String = path.get_file()
 
 	return {
-		"path": path,
-		"filename": filename,
-		"folder": folder,
-		"class_name": class_name_str,
-		"extends": extends_class,
-		"description": description,
-		"line_count": line_count,
-		"variables": variables,
-		"functions": functions,
-		"signals": signals_list,
-		"preloads": preloads,
-		"connections": connections
+		&"path": path,
+		&"filename": filename,
+		&"folder": folder,
+		&"class_name": class_name_str,
+		&"extends": extends_class,
+		&"description": description,
+		&"line_count": line_count,
+		&"variables": variables,
+		&"functions": functions,
+		&"signals": signals_list,
+		&"preloads": preloads,
+		&"connections": connections
 	}
 
 func _infer_type(default_val: String) -> String:
@@ -339,44 +355,46 @@ func _infer_type(default_val: String) -> String:
 
 func map_scenes(args: Dictionary) -> Dictionary:
 	"""Crawl the project and build a map of all scenes."""
-	var root_path: String = str(args.get("root", "res://"))
-	var include_addons: bool = bool(args.get("include_addons", false))
+	var root_path: String = str(args.get(&"root", "res://"))
+	var include_addons: bool = bool(args.get(&"include_addons", false))
 
 	if not root_path.begins_with("res://"):
 		root_path = "res://" + root_path
 
 	# Collect all .tscn files
-	var scene_paths: Array = []
+	var scene_paths: PackedStringArray = []
 	_collect_scenes(root_path, scene_paths, include_addons)
 
 	if scene_paths.is_empty():
-		return {"ok": true, "scene_map": {"scenes": [], "total_scenes": 0}}
+		return {&"ok": true, &"scene_map": {&"scenes": [], &"total_scenes": 0}}
 
 	# Parse each scene
 	var scenes: Array = []
-	for path in scene_paths:
+	for path: String in scene_paths:
 		var info: Dictionary = _parse_scene(path)
 		scenes.append(info)
 
 	# Build edges between scenes (instantiation, preloads)
 	var edges: Array = []
-	for scene in scenes:
-		var from_path: String = scene["path"]
-		for instance in scene.get("instances", []):
-			edges.append({"from": from_path, "to": instance, "type": "instance"})
+	for scene: Dictionary in scenes:
+		var from_path: String = scene[&"path"]
+		for instance: String in scene.get(&"instances", []):
+			edges.append({&"from": from_path, &"to": instance, &"type": "instance"})
 
 	return {
-		"ok": true,
-		"scene_map": {
-			"scenes": scenes,
-			"edges": edges,
-			"total_scenes": scenes.size()
+		&"ok": true,
+		&"scene_map": {
+			&"scenes": scenes,
+			&"edges": edges,
+			&"total_scenes": scenes.size()
 		}
 	}
 
 
-func _collect_scenes(path: String, results: Array, include_addons: bool) -> void:
+func _collect_scenes(path: String, results: PackedStringArray, include_addons: bool, depth: int = 0) -> void:
 	"""Recursively collect all .tscn files."""
+	if depth >= MAX_TRAVERSAL_DEPTH:
+		return
 	var dir := DirAccess.open(path)
 	if dir == null:
 		return
@@ -394,7 +412,7 @@ func _collect_scenes(path: String, results: Array, include_addons: bool) -> void
 			if name == "addons" and not include_addons:
 				name = dir.get_next()
 				continue
-			_collect_scenes(full_path, results, include_addons)
+			_collect_scenes(full_path, results, include_addons, depth + 1)
 		elif name.ends_with(".tscn"):
 			results.append(full_path)
 
@@ -406,7 +424,7 @@ func _parse_scene(path: String) -> Dictionary:
 	"""Parse a scene file and extract its structure."""
 	var file := FileAccess.open(path, FileAccess.READ)
 	if file == null:
-		return {"path": path, "error": "Cannot open file"}
+		return {&"path": path, &"error": "Cannot open file"}
 
 	var content: String = file.get_as_text()
 	file.close()
@@ -420,31 +438,19 @@ func _parse_scene(path: String) -> Dictionary:
 	# Parse .tscn format
 	var lines: PackedStringArray = content.split("\n")
 	var current_node: Dictionary = {}
-	
-	var re_ext_resource := RegEx.new()
-	re_ext_resource.compile('\\[ext_resource.*path="([^"]+)".*type="([^"]+)"')
-	
-	var re_node := RegEx.new()
-	re_node.compile('\\[node name="([^"]+)".*type="([^"]+)"')
-	
-	var re_node_instance := RegEx.new()
-	re_node_instance.compile('\\[node name="([^"]+)".*instance=ExtResource\\("([^"]+)"\\)')
-	
-	var re_script := RegEx.new()
-	re_script.compile('script = ExtResource\\("([^"]+)"\\)')
 
 	var ext_resources: Dictionary = {}  # id -> {path, type}
-	
-	for line in lines:
+
+	for line: String in lines:
 		# External resources
-		var m_ext := re_ext_resource.search(line)
+		var m_ext := _re_ext_resource.search(line)
 		if m_ext:
 			var res_path: String = m_ext.get_string(1)
 			var res_type: String = m_ext.get_string(2)
 			# Extract ID from the line
-			var id_match := RegEx.create_from_string('id="([^"]+)"').search(line)
+			var id_match := _re_ext_id.search(line)
 			if id_match:
-				ext_resources[id_match.get_string(1)] = {"path": res_path, "type": res_type}
+				ext_resources[id_match.get_string(1)] = {&"path": res_path, &"type": res_type}
 				if res_type == "PackedScene":
 					instances.append(res_path)
 				elif res_type == "Script":
@@ -452,29 +458,29 @@ func _parse_scene(path: String) -> Dictionary:
 			continue
 
 		# Regular nodes
-		var m_node := re_node.search(line)
+		var m_node := _re_node.search(line)
 		if m_node:
 			var node_name: String = m_node.get_string(1)
 			var node_type: String = m_node.get_string(2)
 			if root_type.is_empty():
 				root_type = node_type
-			nodes.append({"name": node_name, "type": node_type})
+			nodes.append({&"name": node_name, &"type": node_type})
 			continue
 
 		# Instance nodes
-		var m_inst := re_node_instance.search(line)
+		var m_inst := _re_node_instance.search(line)
 		if m_inst:
 			var node_name: String = m_inst.get_string(1)
-			nodes.append({"name": node_name, "type": "Instance"})
+			nodes.append({&"name": node_name, &"type": "Instance"})
 
 	return {
-		"path": path,
-		"name": scene_name,
-		"root_type": root_type,
-		"nodes": nodes,
-		"instances": instances,
-		"scripts": scripts,
-		"node_count": nodes.size()
+		&"path": path,
+		&"name": scene_name,
+		&"root_type": root_type,
+		&"nodes": nodes,
+		&"instances": instances,
+		&"scripts": scripts,
+		&"node_count": nodes.size()
 	}
 
 
@@ -495,30 +501,30 @@ func _internal_refresh_map(args: Dictionary) -> Dictionary:
 
 func _internal_create_script_file(args: Dictionary) -> Dictionary:
 	"""Create a new script file."""
-	var script_path: String = args.get("path", "")
-	var extends_type: String = args.get("extends", "Node")
-	var class_name_str: String = args.get("class_name", "")
-	
+	var script_path: String = args.get(&"path", "")
+	var extends_type: String = args.get(&"extends", "Node")
+	var class_name_str: String = args.get(&"class_name", "")
+
 	if script_path.is_empty():
-		return {"ok": false, "error": "No path provided"}
-	
+		return {&"ok": false, &"error": "No path provided"}
+
 	if not script_path.begins_with("res://"):
 		script_path = "res://" + script_path
-	
+
 	if not script_path.ends_with(".gd"):
 		script_path += ".gd"
-	
+
 	# Check if file already exists
 	if FileAccess.file_exists(script_path):
-		return {"ok": false, "error": "File already exists: " + script_path}
-	
+		return {&"ok": false, &"error": "File already exists: " + script_path}
+
 	# Create directory if needed
 	var dir_path: String = script_path.get_base_dir()
 	if not DirAccess.dir_exists_absolute(dir_path):
 		var err := DirAccess.make_dir_recursive_absolute(dir_path)
 		if err != OK:
-			return {"ok": false, "error": "Failed to create directory"}
-	
+			return {&"ok": false, &"error": "Failed to create directory"}
+
 	# Build script content
 	var content := ""
 	if not class_name_str.is_empty():
@@ -527,57 +533,57 @@ func _internal_create_script_file(args: Dictionary) -> Dictionary:
 	content += "\n\n"
 	content += "func _ready() -> void:\n"
 	content += "\tpass\n"
-	
+
 	# Write file
 	var file := FileAccess.open(script_path, FileAccess.WRITE)
 	if file == null:
-		return {"ok": false, "error": "Cannot create file: " + script_path}
-	
+		return {&"ok": false, &"error": "Cannot create file: " + script_path}
+
 	file.store_string(content)
 	file.close()
-	
-	return {"ok": true, "path": script_path}
+
+	return {&"ok": true, &"path": script_path}
 
 
 func _internal_modify_variable(args: Dictionary) -> Dictionary:
 	"""Add, update, or delete a variable in a script file."""
-	var script_path: String = args.get("path", "")
-	var action: String = args.get("action", "")  # "add", "update", "delete"
-	var old_name: String = args.get("old_name", "")
-	var new_name: String = args.get("name", "")
-	var var_type: String = args.get("type", "")
-	var default_val: String = args.get("default", "")
-	var exported: bool = args.get("exported", false)
-	var onready: bool = args.get("onready", false)
-	
+	var script_path: String = args.get(&"path", "")
+	var action: String = args.get(&"action", "")  # "add", "update", "delete"
+	var old_name: String = args.get(&"old_name", "")
+	var new_name: String = args.get(&"name", "")
+	var var_type: String = args.get(&"type", "")
+	var default_val: String = args.get(&"default", "")
+	var exported: bool = args.get(&"exported", false)
+	var onready: bool = args.get(&"onready", false)
+
 	if script_path.is_empty():
-		return {"ok": false, "error": "No script path provided"}
-	
+		return {&"ok": false, &"error": "No script path provided"}
+
 	var file := FileAccess.open(script_path, FileAccess.READ)
 	if file == null:
-		return {"ok": false, "error": "Cannot open file: " + script_path}
-	
+		return {&"ok": false, &"error": "Cannot open file: " + script_path}
+
 	var content: String = file.get_as_text()
 	file.close()
-	
+
 	var lines: Array = Array(content.split("\n"))
 	var modified := false
-	
+
 	if action == "delete":
 		# Find and remove the variable declaration
 		var pattern := RegEx.new()
 		pattern.compile("^(@export(?:\\([^)]*\\))?\\s+)?(?:@onready\\s+)?var\\s+" + old_name + "\\s*(?::|=|$)")
-		for i in range(lines.size() - 1, -1, -1):
+		for i: int in range(lines.size() - 1, -1, -1):
 			if pattern.search(lines[i].strip_edges()):
 				lines.remove_at(i)
 				modified = true
 				break
-	
+
 	elif action == "update":
 		# Find and update the variable declaration
 		var pattern := RegEx.new()
 		pattern.compile("^(@export(?:\\([^)]*\\))?\\s+)?(@onready\\s+)?var\\s+" + old_name + "\\s*(?::\\s*\\w+)?(?:\\s*=\\s*.+)?$")
-		for i in range(lines.size()):
+		for i: int in range(lines.size()):
 			var m := pattern.search(lines[i].strip_edges())
 			if m:
 				# Use onready from args, not from matched pattern
@@ -585,60 +591,60 @@ func _internal_modify_variable(args: Dictionary) -> Dictionary:
 				lines[i] = new_line
 				modified = true
 				break
-	
+
 	elif action == "add":
 		# Find position to insert (after last variable, before first function)
 		var insert_pos := _find_var_insert_position(lines, exported)
 		var new_line := _build_var_line(new_name, var_type, default_val, exported, false)
 		lines.insert(insert_pos, new_line)
 		modified = true
-	
+
 	if modified:
 		var new_content := "\n".join(PackedStringArray(lines))
 		var write_file := FileAccess.open(script_path, FileAccess.WRITE)
 		if write_file == null:
-			return {"ok": false, "error": "Cannot write to file: " + script_path}
+			return {&"ok": false, &"error": "Cannot write to file: " + script_path}
 		write_file.store_string(new_content)
 		write_file.close()
-		return {"ok": true, "action": action, "variable": new_name}
-	
-	return {"ok": false, "error": "Variable not found: " + old_name}
+		return {&"ok": true, &"action": action, &"variable": new_name}
+
+	return {&"ok": false, &"error": "Variable not found: " + old_name}
 
 
 func _internal_modify_signal(args: Dictionary) -> Dictionary:
 	"""Add, update, or delete a signal in a script file."""
-	var script_path: String = args.get("path", "")
-	var action: String = args.get("action", "")
-	var old_name: String = args.get("old_name", "")
-	var new_name: String = args.get("name", "")
-	var params: String = args.get("params", "")
-	
+	var script_path: String = args.get(&"path", "")
+	var action: String = args.get(&"action", "")
+	var old_name: String = args.get(&"old_name", "")
+	var new_name: String = args.get(&"name", "")
+	var params: String = args.get(&"params", "")
+
 	if script_path.is_empty():
-		return {"ok": false, "error": "No script path provided"}
-	
+		return {&"ok": false, &"error": "No script path provided"}
+
 	var file := FileAccess.open(script_path, FileAccess.READ)
 	if file == null:
-		return {"ok": false, "error": "Cannot open file: " + script_path}
-	
+		return {&"ok": false, &"error": "Cannot open file: " + script_path}
+
 	var content: String = file.get_as_text()
 	file.close()
-	
+
 	var lines: Array = Array(content.split("\n"))
 	var modified := false
-	
+
 	if action == "delete":
 		var pattern := RegEx.new()
 		pattern.compile("^signal\\s+" + old_name + "(?:\\s*\\(|$)")
-		for i in range(lines.size() - 1, -1, -1):
+		for i: int in range(lines.size() - 1, -1, -1):
 			if pattern.search(lines[i].strip_edges()):
 				lines.remove_at(i)
 				modified = true
 				break
-	
+
 	elif action == "update":
 		var pattern := RegEx.new()
 		pattern.compile("^signal\\s+" + old_name + "(?:\\s*\\([^)]*\\))?$")
-		for i in range(lines.size()):
+		for i: int in range(lines.size()):
 			if pattern.search(lines[i].strip_edges()):
 				var new_line := "signal " + new_name
 				if not params.is_empty():
@@ -646,7 +652,7 @@ func _internal_modify_signal(args: Dictionary) -> Dictionary:
 				lines[i] = new_line
 				modified = true
 				break
-	
+
 	elif action == "add":
 		var insert_pos := _find_signal_insert_position(lines)
 		var new_line := "signal " + new_name
@@ -654,45 +660,45 @@ func _internal_modify_signal(args: Dictionary) -> Dictionary:
 			new_line += "(" + params + ")"
 		lines.insert(insert_pos, new_line)
 		modified = true
-	
+
 	if modified:
 		var new_content := "\n".join(PackedStringArray(lines))
 		var write_file := FileAccess.open(script_path, FileAccess.WRITE)
 		if write_file == null:
-			return {"ok": false, "error": "Cannot write to file: " + script_path}
+			return {&"ok": false, &"error": "Cannot write to file: " + script_path}
 		write_file.store_string(new_content)
 		write_file.close()
-		return {"ok": true, "action": action, "signal": new_name}
-	
-	return {"ok": false, "error": "Signal not found: " + old_name}
+		return {&"ok": true, &"action": action, &"signal": new_name}
+
+	return {&"ok": false, &"error": "Signal not found: " + old_name}
 
 
 func _internal_modify_function(args: Dictionary) -> Dictionary:
 	"""Update a function's body in a script file."""
-	var script_path: String = args.get("path", "")
-	var func_name: String = args.get("name", "")
-	var new_body: String = args.get("body", "")
-	
+	var script_path: String = args.get(&"path", "")
+	var func_name: String = args.get(&"name", "")
+	var new_body: String = args.get(&"body", "")
+
 	if script_path.is_empty() or func_name.is_empty():
-		return {"ok": false, "error": "Missing path or function name"}
-	
+		return {&"ok": false, &"error": "Missing path or function name"}
+
 	var file := FileAccess.open(script_path, FileAccess.READ)
 	if file == null:
-		return {"ok": false, "error": "Cannot open file: " + script_path}
-	
+		return {&"ok": false, &"error": "Cannot open file: " + script_path}
+
 	var content: String = file.get_as_text()
 	file.close()
-	
+
 	var lines: Array = Array(content.split("\n"))
-	
+
 	# Find the function
 	var re_func := RegEx.new()
 	re_func.compile("^func\\s+" + func_name + "\\s*\\(")
-	
+
 	var func_start := -1
 	var func_end := -1
-	
-	for i in range(lines.size()):
+
+	for i: int in range(lines.size()):
 		if func_start == -1:
 			if re_func.search(lines[i].strip_edges()):
 				func_start = i
@@ -702,63 +708,63 @@ func _internal_modify_function(args: Dictionary) -> Dictionary:
 			if not stripped.is_empty() and not lines[i].begins_with("\t") and not lines[i].begins_with(" ") and not stripped.begins_with("#"):
 				func_end = i
 				break
-	
+
 	if func_start == -1:
-		return {"ok": false, "error": "Function not found: " + func_name}
-	
+		return {&"ok": false, &"error": "Function not found: " + func_name}
+
 	if func_end == -1:
 		func_end = lines.size()
-	
+
 	# Remove trailing empty lines from function body
 	while func_end > func_start + 1 and lines[func_end - 1].strip_edges().is_empty():
 		func_end -= 1
-	
+
 	# Replace function body
 	var new_lines := Array(new_body.split("\n"))
-	
+
 	# Remove old function lines
-	for i in range(func_end - 1, func_start - 1, -1):
+	for i: int in range(func_end - 1, func_start - 1, -1):
 		lines.remove_at(i)
-	
+
 	# Insert new function lines
-	for i in range(new_lines.size()):
+	for i: int in range(new_lines.size()):
 		lines.insert(func_start + i, new_lines[i])
-	
+
 	var new_content := "\n".join(PackedStringArray(lines))
 	var write_file := FileAccess.open(script_path, FileAccess.WRITE)
 	if write_file == null:
-		return {"ok": false, "error": "Cannot write to file: " + script_path}
+		return {&"ok": false, &"error": "Cannot write to file: " + script_path}
 	write_file.store_string(new_content)
 	write_file.close()
-	
-	return {"ok": true, "function": func_name}
+
+	return {&"ok": true, &"function": func_name}
 
 
 func _internal_modify_function_delete(args: Dictionary) -> Dictionary:
 	"""Delete a function from a script file."""
-	var script_path: String = args.get("path", "")
-	var func_name: String = args.get("name", "")
-	
+	var script_path: String = args.get(&"path", "")
+	var func_name: String = args.get(&"name", "")
+
 	if script_path.is_empty() or func_name.is_empty():
-		return {"ok": false, "error": "Missing path or function name"}
-	
+		return {&"ok": false, &"error": "Missing path or function name"}
+
 	var file := FileAccess.open(script_path, FileAccess.READ)
 	if file == null:
-		return {"ok": false, "error": "Cannot open file: " + script_path}
-	
+		return {&"ok": false, &"error": "Cannot open file: " + script_path}
+
 	var content: String = file.get_as_text()
 	file.close()
-	
+
 	var lines: Array = Array(content.split("\n"))
-	
+
 	# Find the function
 	var re_func := RegEx.new()
 	re_func.compile("^func\\s+" + func_name + "\\s*\\(")
-	
+
 	var func_start := -1
 	var func_end := -1
-	
-	for i in range(lines.size()):
+
+	for i: int in range(lines.size()):
 		if func_start == -1:
 			if re_func.search(lines[i].strip_edges()):
 				func_start = i
@@ -768,85 +774,82 @@ func _internal_modify_function_delete(args: Dictionary) -> Dictionary:
 			if not stripped.is_empty() and not lines[i].begins_with("\t") and not lines[i].begins_with(" ") and not stripped.begins_with("#"):
 				func_end = i
 				break
-	
+
 	if func_start == -1:
-		return {"ok": false, "error": "Function not found: " + func_name}
-	
+		return {&"ok": false, &"error": "Function not found: " + func_name}
+
 	if func_end == -1:
 		func_end = lines.size()
-	
+
 	# Remove trailing empty lines before the function
 	while func_end > func_start + 1 and lines[func_end - 1].strip_edges().is_empty():
 		func_end -= 1
-	
+
 	# Remove the function lines
-	for i in range(func_end - 1, func_start - 1, -1):
+	for i: int in range(func_end - 1, func_start - 1, -1):
 		lines.remove_at(i)
-	
+
 	# Remove extra blank lines that might be left
 	# (but keep at least one blank line between declarations)
-	
+
 	var new_content := "\n".join(PackedStringArray(lines))
 	var write_file := FileAccess.open(script_path, FileAccess.WRITE)
 	if write_file == null:
-		return {"ok": false, "error": "Cannot write to file: " + script_path}
+		return {&"ok": false, &"error": "Cannot write to file: " + script_path}
 	write_file.store_string(new_content)
 	write_file.close()
-	
-	return {"ok": true, "deleted": func_name}
+
+	return {&"ok": true, &"deleted": func_name}
 
 
 func _internal_find_usages(args: Dictionary) -> Dictionary:
 	"""Find all usages of a variable, signal, or function across all scripts."""
-	var name: String = args.get("name", "")
-	var item_type: String = args.get("type", "")  # "variable", "signal", "function"
-	var root_path: String = args.get("root", "res://")
-	
+	var name: String = args.get(&"name", "")
+	var item_type: String = args.get(&"type", "")  # "variable", "signal", "function"
+	var root_path: String = args.get(&"root", "res://")
+
 	if name.is_empty():
-		return {"ok": false, "error": "No name provided"}
-	
+		return {&"ok": false, &"error": "No name provided"}
+
 	# Collect all scripts
-	var script_paths: Array = []
+	var script_paths: PackedStringArray = []
 	_collect_scripts(root_path, script_paths, false)
-	
+
 	var usages: Array = []
-	
-	# Build regex pattern based on type
-	var pattern := RegEx.new()
-	if item_type == "signal":
-		# Match: signal_name.emit() or signal_name.connect() or .signal_name.
-		pattern.compile("\\b" + name + "\\b")
-	else:
-		# Match word boundary for variables and functions
-		pattern.compile("\\b" + name + "\\b")
-	
-	for path in script_paths:
+
+	# Build regex patterns once before the loop
+	var pattern := RegEx.create_from_string("\\b" + name + "\\b")
+	var skip_pattern: RegEx = null
+	if item_type == "variable":
+		skip_pattern = RegEx.create_from_string("^\\s*(@export)?\\s*var\\s+" + name + "\\b")
+	elif item_type == "signal":
+		skip_pattern = RegEx.create_from_string("^\\s*signal\\s+" + name + "\\b")
+	elif item_type == "function":
+		skip_pattern = RegEx.create_from_string("^\\s*func\\s+" + name + "\\s*\\(")
+
+	for path: String in script_paths:
 		var file := FileAccess.open(path, FileAccess.READ)
 		if file == null:
 			continue
-		
+
 		var content: String = file.get_as_text()
 		file.close()
-		
+
 		var lines: PackedStringArray = content.split("\n")
-		for i in range(lines.size()):
+		for i: int in range(lines.size()):
 			var line: String = lines[i]
 			if pattern.search(line):
 				# Skip the declaration line itself
-				if item_type == "variable" and RegEx.create_from_string("^\\s*(@export)?\\s*var\\s+" + name + "\\b").search(line):
+				if skip_pattern and skip_pattern.search(line):
 					continue
-				if item_type == "signal" and RegEx.create_from_string("^\\s*signal\\s+" + name + "\\b").search(line):
-					continue
-				if item_type == "function" and RegEx.create_from_string("^\\s*func\\s+" + name + "\\s*\\(").search(line):
-					continue
-				
+
 				usages.append({
-					"file": path,
-					"line": i + 1,
-					"code": line.strip_edges()
+					&"file": path,
+					&"line": i + 1,
+					&"code": line.strip_edges()
 				})
-	
-	return {"ok": true, "usages": usages, "count": usages.size()}
+
+	return {&"ok": true, &"usages": usages, &"count": usages.size()}
 
 
 # Helper functions for file modification
@@ -870,24 +873,17 @@ func _find_var_insert_position(lines: Array, exported: bool) -> int:
 	var last_var_line := -1
 	var first_func_line := -1
 	var after_class_decl := 0
-	
-	var re_var := RegEx.new()
-	re_var.compile("^(@export)?\\s*(@onready)?\\s*var\\s+")
-	var re_func := RegEx.new()
-	re_func.compile("^func\\s+")
-	var re_class := RegEx.new()
-	re_class.compile("^(class_name|extends)\\s+")
-	
-	for i in range(lines.size()):
+
+	for i: int in range(lines.size()):
 		var stripped: String = lines[i].strip_edges()
-		if re_class.search(stripped):
+		if _re_helper_class.search(stripped):
 			after_class_decl = i + 1
-		if re_var.search(stripped):
+		if _re_helper_var.search(stripped):
 			last_var_line = i
-		if re_func.search(stripped) and first_func_line == -1:
+		if _re_helper_func.search(stripped) and first_func_line == -1:
 			first_func_line = i
 			break
-	
+
 	# Insert after last variable, or before first function, or after class declarations
 	if last_var_line != -1:
 		return last_var_line + 1
@@ -901,23 +897,16 @@ func _find_signal_insert_position(lines: Array) -> int:
 	var last_signal_line := -1
 	var first_var_line := -1
 	var after_class_decl := 0
-	
-	var re_signal := RegEx.new()
-	re_signal.compile("^signal\\s+")
-	var re_var := RegEx.new()
-	re_var.compile("^(@export)?\\s*var\\s+")
-	var re_class := RegEx.new()
-	re_class.compile("^(class_name|extends)\\s+")
-	
-	for i in range(lines.size()):
+
+	for i: int in range(lines.size()):
 		var stripped: String = lines[i].strip_edges()
-		if re_class.search(stripped):
+		if _re_helper_class.search(stripped):
 			after_class_decl = i + 1
-		if re_signal.search(stripped):
+		if _re_helper_signal.search(stripped):
 			last_signal_line = i
-		if re_var.search(stripped) and first_var_line == -1:
+		if _re_helper_var.search(stripped) and first_var_line == -1:
 			first_var_line = i
-	
+
 	# Insert after last signal, or before first var, or after class declarations
 	if last_signal_line != -1:
 		return last_signal_line + 1
@@ -935,49 +924,49 @@ func _internal_get_scene_hierarchy(args: Dictionary) -> Dictionary:
 	"""Get scene hierarchy for visualizer."""
 	if _scene_tools_ref and _scene_tools_ref.has_method("get_scene_hierarchy"):
 		return _scene_tools_ref.get_scene_hierarchy(args)
-	return {"ok": false, "error": "Scene tools not available"}
+	return {&"ok": false, &"error": "Scene tools not available"}
 
 
 func _internal_get_scene_node_properties(args: Dictionary) -> Dictionary:
 	"""Get node properties for visualizer panel."""
 	if _scene_tools_ref and _scene_tools_ref.has_method("get_scene_node_properties"):
 		return _scene_tools_ref.get_scene_node_properties(args)
-	return {"ok": false, "error": "Scene tools not available"}
+	return {&"ok": false, &"error": "Scene tools not available"}
 
 
 func _internal_set_scene_node_property(args: Dictionary) -> Dictionary:
 	"""Set node property from visualizer panel."""
 	if _scene_tools_ref and _scene_tools_ref.has_method("set_scene_node_property"):
 		return _scene_tools_ref.set_scene_node_property(args)
-	return {"ok": false, "error": "Scene tools not available"}
+	return {&"ok": false, &"error": "Scene tools not available"}
 
 
 func _internal_add_scene_node(args: Dictionary) -> Dictionary:
 	"""Add a node to a scene from visualizer."""
 	if _scene_tools_ref and _scene_tools_ref.has_method("add_node"):
 		return _scene_tools_ref.add_node(args)
-	return {"ok": false, "error": "Scene tools not available"}
+	return {&"ok": false, &"error": "Scene tools not available"}
 
 
 func _internal_remove_scene_node(args: Dictionary) -> Dictionary:
 	"""Remove a node from a scene from visualizer."""
 	if _scene_tools_ref and _scene_tools_ref.has_method("remove_node"):
 		return _scene_tools_ref.remove_node(args)
-	return {"ok": false, "error": "Scene tools not available"}
+	return {&"ok": false, &"error": "Scene tools not available"}
 
 
 func _internal_rename_scene_node(args: Dictionary) -> Dictionary:
 	"""Rename a node in a scene from visualizer."""
 	if _scene_tools_ref and _scene_tools_ref.has_method("rename_node"):
 		return _scene_tools_ref.rename_node(args)
-	return {"ok": false, "error": "Scene tools not available"}
+	return {&"ok": false, &"error": "Scene tools not available"}
 
 
 func _internal_move_scene_node(args: Dictionary) -> Dictionary:
 	"""Move/reorder a node in a scene from visualizer."""
 	if _scene_tools_ref and _scene_tools_ref.has_method("move_node"):
 		return _scene_tools_ref.move_node(args)
-	return {"ok": false, "error": "Scene tools not available"}
+	return {&"ok": false, &"error": "Scene tools not available"}
 
 
 # Simpler aliases for context menu actions
@@ -985,39 +974,39 @@ func _internal_add_node(args: Dictionary) -> Dictionary:
 	"""Add a node to a scene."""
 	if _scene_tools_ref and _scene_tools_ref.has_method("add_node"):
 		return _scene_tools_ref.add_node(args)
-	return {"ok": false, "error": "Scene tools not available"}
+	return {&"ok": false, &"error": "Scene tools not available"}
 
 
 func _internal_remove_node(args: Dictionary) -> Dictionary:
 	"""Remove a node from a scene."""
 	if _scene_tools_ref and _scene_tools_ref.has_method("remove_node"):
 		return _scene_tools_ref.remove_node(args)
-	return {"ok": false, "error": "Scene tools not available"}
+	return {&"ok": false, &"error": "Scene tools not available"}
 
 
 func _internal_rename_node(args: Dictionary) -> Dictionary:
 	"""Rename a node in a scene."""
 	if _scene_tools_ref and _scene_tools_ref.has_method("rename_node"):
 		return _scene_tools_ref.rename_node(args)
-	return {"ok": false, "error": "Scene tools not available"}
+	return {&"ok": false, &"error": "Scene tools not available"}
 
 
 func _internal_move_node(args: Dictionary) -> Dictionary:
 	"""Move/reorder a node in a scene."""
 	if _scene_tools_ref and _scene_tools_ref.has_method("move_node"):
 		return _scene_tools_ref.move_node(args)
-	return {"ok": false, "error": "Scene tools not available"}
+	return {&"ok": false, &"error": "Scene tools not available"}
 
 
 func _internal_duplicate_node(args: Dictionary) -> Dictionary:
 	"""Duplicate a node in a scene."""
 	if _scene_tools_ref and _scene_tools_ref.has_method("duplicate_node"):
 		return _scene_tools_ref.duplicate_node(args)
-	return {"ok": false, "error": "Scene tools not available"}
+	return {&"ok": false, &"error": "Scene tools not available"}
 
 
 func _internal_reorder_node(args: Dictionary) -> Dictionary:
 	"""Reorder a node within its parent (change sibling index)."""
 	if _scene_tools_ref and _scene_tools_ref.has_method("reorder_node"):
 		return _scene_tools_ref.reorder_node(args)
-	return {"ok": false, "error": "Scene tools not available"}
+	return {&"ok": false, &"error": "Scene tools not available"}


### PR DESCRIPTION
**StringName dictionary keys** — Converted all dictionary key literals across 7 files from `"key"` to `&"key"` (StringName). Dictionary lookups and comparisons go from O(n) character comparison to O(1) pointer equality. Affects every `args.get()`, response dictionary, property iteration, and type serialization call.

**PackedStringArray + join** — Replaced O(n²) string concatenation loops with PackedStringArray append + single `"\n".join()` in `_dump_node` (scene tree dump) and `_extract_file_line` (digit extraction).

**Typed for loops** — Added explicit type annotations to all 53+ `for` loops across all tool files (`for child: Node in ...`, `for prop: Dictionary in ...`, etc.). Skips Variant unboxing on every iteration.

**Batch thread dispatch** — Replaced per-request `pop_front()` (O(n) array shift) with batch swap pattern (O(1)) in `_thread_loop`.

**Const skip extensions** — Converted runtime `_init()` dictionary construction to `const _SKIP_EXTENSIONS: Dictionary` for compile-time initialization.

**Reduced dictionary lookups** — `_parse_value`: single `.get("type", "")` instead of `.has("type")` + `value["type"]` (1 lookup vs 2).

**Hoisted hot-path allocations** — Moved array literals used in `in` checks inside property loops to class-level `const Dictionary` with `.has()` for O(1) lookup instead of per-iteration array allocation.

**Bulk file reads** — `read_file` uses single `get_buffer()` syscall for all access patterns instead of per-line reads. `search_project` does whole-file `find()` before splitting to skip non-matching files entirely.

**O(1) extension filtering** — `_collect_files_recursive` uses Dictionary `.has()` on file extensions instead of iterating a list.