### PR TITLE
Add get_debugger_errors tool to read Debugger > Errors tab

### DIFF
--- a/addons/godot_mcp/tool_executor.gd
+++ b/addons/godot_mcp/tool_executor.gd
@@ -86,6 +86,7 @@ func _init_tools() -> void:
 		&"get_node_properties": [_project_tools, &"get_node_properties"],
 		&"get_console_log": [_project_tools, &"get_console_log"],
 		&"get_errors": [_project_tools, &"get_errors"],
+		&"get_debugger_errors": [_project_tools, &"get_debugger_errors"],
 		&"clear_console_log": [_project_tools, &"clear_console_log"],
 		&"open_in_godot": [_project_tools, &"open_in_godot"],
 		&"scene_tree_dump": [_project_tools, &"scene_tree_dump"],

--- a/addons/godot_mcp/tools/project_tools.gd
+++ b/addons/godot_mcp/tools/project_tools.gd
@@ -13,6 +13,9 @@ var _editor_plugin: EditorPlugin = null
 # Cached reference to the editor Output panel's RichTextLabel.
 var _editor_log_rtl: RichTextLabel = null
 
+# Cached reference to the Debugger > Errors tab's Tree widget.
+var _debugger_error_tree: Tree = null
+
 # Character offset for clear_console_log.
 var _clear_char_offset: int = 0
 
@@ -638,6 +641,115 @@ func get_errors(args: Dictionary) -> Dictionary:
 	var errors := all_errors.slice(start)
 	return {&"ok": true, &"errors": errors, &"error_count": errors.size(),
 		&"summary": "%d error(s) found" % errors.size()}
+
+# =============================================================================
+# get_debugger_errors
+# =============================================================================
+func get_debugger_errors(args: Dictionary) -> Dictionary:
+	var max_errors: int = int(args.get(&"max_errors", 50))
+
+	var tree := _get_debugger_error_tree()
+	if not tree:
+		var base := _editor_plugin.get_editor_interface().get_base_control() if _editor_plugin else null
+		var debugger := _find_node_by_class(base, "ScriptEditorDebugger") if base else null
+		var debug_info := ""
+		if not debugger:
+			debug_info = "ScriptEditorDebugger node not found in editor tree."
+		else:
+			debug_info = "ScriptEditorDebugger found but no Tree widget located. Children: "
+			var child_info: Array = []
+			for child: Node in debugger.get_children():
+				child_info.append("%s (%s)" % [child.name, child.get_class()])
+			debug_info += ", ".join(child_info)
+		return {&"ok": false,
+			&"error": "Could not access the Debugger Errors panel. " + debug_info}
+
+	var root := tree.get_root()
+	if not root:
+		return {&"ok": true, &"errors": [], &"error_count": 0,
+			&"summary": "0 debugger error(s) found"}
+
+	var errors: Array = []
+	var item := root.get_first_child()
+	while item:
+		var col_count := tree.columns
+		var parts: Array = []
+		for col: int in range(col_count):
+			var text: String = item.get_text(col)
+			if not text.strip_edges().is_empty():
+				parts.append(text)
+		var message: String = " | ".join(parts) if not parts.is_empty() else ""
+
+		if message.strip_edges().is_empty():
+			item = item.get_next()
+			continue
+
+		var severity := "error"
+		var msg_lower := message.to_lower()
+		if "warning" in msg_lower:
+			severity = "warning"
+
+		var error_info := {&"message": message, &"severity": severity}
+
+		var loc := _extract_file_line(message)
+		if not loc.is_empty():
+			error_info[&"file"] = loc.get(&"file", "")
+			error_info[&"line"] = loc.get(&"line", 0)
+
+		var stack_trace: Array = []
+		var child_item := item.get_first_child()
+		while child_item:
+			var trace_parts: Array = []
+			for col: int in range(col_count):
+				var t: String = child_item.get_text(col)
+				if not t.strip_edges().is_empty():
+					trace_parts.append(t)
+			if not trace_parts.is_empty():
+				stack_trace.append(" | ".join(trace_parts))
+			child_item = child_item.get_next()
+		if not stack_trace.is_empty():
+			error_info[&"stack_trace"] = stack_trace
+
+		errors.append(error_info)
+		item = item.get_next()
+
+	var start := maxi(0, errors.size() - max_errors)
+	var result := errors.slice(start)
+	return {&"ok": true, &"errors": result, &"error_count": result.size(),
+		&"summary": "%d debugger error(s) found" % result.size()}
+
+func _get_debugger_error_tree() -> Tree:
+	if is_instance_valid(_debugger_error_tree):
+		return _debugger_error_tree
+	if not _editor_plugin:
+		return null
+	var base := _editor_plugin.get_editor_interface().get_base_control()
+	var debugger := _find_node_by_class(base, "ScriptEditorDebugger")
+	if not debugger:
+		return null
+	var tree := _find_error_tree(debugger)
+	if tree:
+		_debugger_error_tree = tree
+	return _debugger_error_tree
+
+func _find_error_tree(node: Node) -> Tree:
+	var candidates: Array[Tree] = []
+	_collect_trees(node, candidates)
+	for tree: Tree in candidates:
+		var p := tree.get_parent()
+		while p and p != node:
+			if "Error" in p.name or "error" in p.name:
+				return tree
+			p = p.get_parent()
+	if not candidates.is_empty():
+		return candidates[0]
+	return null
+
+func _collect_trees(node: Node, out: Array[Tree]) -> void:
+	if node is Tree:
+		out.append(node as Tree)
+	for child: Node in node.get_children():
+		_collect_trees(child, out)
 
 func _extract_file_line(text: String) -> Dictionary:
 	var idx := text.find("res://")

--- a/mcp-server/src/tools/project-tools.ts
+++ b/mcp-server/src/tools/project-tools.ts
@@ -89,6 +89,19 @@ export const projectTools: ToolDefinition[] = [
     }
   },
   {
+    name: 'get_debugger_errors',
+    description: 'Get runtime errors and warnings from the Godot Debugger > Errors tab. Unlike get_errors (which reads the Output panel), this reads the actual debugger error list that appears during gameplay, including script errors, null references, and engine warnings.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        max_errors: {
+          type: 'number',
+          description: 'Maximum number of errors to return (default: 50)'
+        }
+      }
+    }
+  },
+  {
     name: 'clear_console_log',
     description: 'Mark the current position in the Godot editor log. Subsequent get_console_log and get_errors calls will only return output after this point.',
     inputSchema: {


### PR DESCRIPTION
Hello! I hope you are well. Before I dive into the PR I just wanted to take a moment to say thank you for writing this. I have been enjoying working on a side-project in my idle time using Godot 4 and this MCP. I appreciate your recent patches including v0.2.8 for handling stale processes.  Before this I had not used Godot or written GDScript, but I have had great success building and iterating on my 3D game while treating the Godot application as effectively headless.

One issue I've run into though is that the MCP doesn't currently have access to errors which are logged inside the Debugger at runtime.

<img width="1999" height="1194" alt="image" src="https://github.com/user-attachments/assets/022ba55e-70db-4283-8f92-9f21d4e9eee3" />

This requires me to copy/paste these errors into my agent to debug them. After the 20th time of doing this I wired up a tool for the MCP successfully based on the existing `get_errors` tool. I figured I would pass it back to you, to merge in or integrate yourself.  

<img width="1840" height="1099" alt="image" src="https://github.com/user-attachments/assets/74ea05e9-56cc-43fa-b431-10642186a1bf" />

Thank you again for this project! Below is a write-up from our friend Claude: 

--------

## Summary

Adds a new `get_debugger_errors` tool that reads runtime errors from the Debugger > Errors tab. The existing `get_errors` tool only reads the Output panel, which misses runtime script errors, null references, and engine warnings that appear exclusively in the debugger during gameplay.

## Approach

Follows the same Tree/node scraping pattern used by `get_errors` and `get_console_log` — walks the editor node tree to find `ScriptEditorDebugger`, locates the error `Tree` widget, and reads entries with their stack traces. Same level of fragility as existing implementations.

## Test plan

- Verified in Godot 4.6.1 on macOS
- Confirmed errors and stack traces are returned correctly during gameplay
- Build passes (`npm run build`)