### PR TITLE
Fix WebSocket server binding to IPv4 (127.0.0.1)

### DIFF
--- a/mcp-server/src/godot-bridge.ts
+++ b/mcp-server/src/godot-bridge.ts
@@ -59,7 +59,7 @@ export class GodotBridge {
   start(): Promise<void> {
     return new Promise((resolve, reject) => {
       try {
-        this.wss = new WebSocketServer({ port: this.port });
+        this.wss = new WebSocketServer({ host: '127.0.0.1', port: this.port });
 
         this.wss.on('connection', (ws, req) => {
           this.handleConnection(ws, req);


### PR DESCRIPTION
## Summary

- Fixes the WebSocket server to explicitly bind to `127.0.0.1` (IPv4) instead of the default `::` (IPv6)
- One-line change in `godot-bridge.ts` — matches what Godot's `WebSocketPeer` connects to
- Likely root cause of #10 (server never connecting on Win11/Linux)

## Problem

The `ws` library defaults to `::` (IPv6). Godot connects to `ws://127.0.0.1:6505` (IPv4). On systems without transparent IPv6→IPv4 bridging, the connection silently fails.

## Change

```diff
- this.wss = new WebSocketServer({ port: this.port });
+ this.wss = new WebSocketServer({ host: '127.0.0.1', port: this.port });
```

## Testing

Tested on macOS with Godot 4.6.1. Before: `lsof` showed `IPv6 TCP *:6505`. After: `IPv4 TCP localhost:6505`. Godot connects immediately.

Closes #17
Likely fixes #10