### PR TITLE
fix: prevent zombie server when WebSocket/HTTP startup fails

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "godot-mcp-server",
-  "version": "0.1.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "godot-mcp-server",
-      "version": "0.1.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@modelcontextprotocol/sdk": "~1.25.2",
         "ws": "^8.18.0"
       },
       "bin": {
@@ -824,7 +824,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1609,7 +1608,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -322,6 +322,28 @@ async function startPrimary(): Promise<void> {
     }
   }
 
+  // --- Verify at least one server is listening ---
+  const webSocketListening = godotBridge.getStatus().port > 0;
+  const httpListening = httpServer.isListening();
+
+  if (!webSocketListening && !httpListening) {
+    console.error(`[${SERVER_NAME}] ❌ Fatal: Neither WebSocket nor HTTP server started.`);
+    console.error(`[${SERVER_NAME}] WebSocket server (port ${WEBSOCKET_PORT}): ${webSocketListening ? 'OK' : 'FAILED'}`);
+    console.error(`[${SERVER_NAME}] HTTP server (port ${HTTP_PORT}): ${httpListening ? 'OK' : 'FAILED'}`);
+    console.error(`[${SERVER_NAME}] Check for port conflicts, permissions, or network issues.`);
+    console.error(`[${SERVER_NAME}] Cannot continue without at least one listening server.`);
+    godotBridge?.stop();
+    httpServer.stop();
+    process.exit(1);
+  }
+
+  if (!webSocketListening) {
+    console.error(`[${SERVER_NAME}] ⚠️  WebSocket server failed to start. Godot connection will not work.`);
+  }
+  if (!httpListening) {
+    console.error(`[${SERVER_NAME}] ⚠️  HTTP server failed to start. Proxy clients will not be able to connect.`);
+  }
+
   console.error(`[${SERVER_NAME}] Available tools: ${allTools.length + 1}`);
   console.error(`[${SERVER_NAME}] Waiting for Godot editor connection...`);
 

--- a/mcp-server/src/primary-http.ts
+++ b/mcp-server/src/primary-http.ts
@@ -71,6 +71,10 @@ export class PrimaryHttpServer {
     }
   }
 
+  isListening(): boolean {
+    return this.server?.listening || false;
+  }
+
   private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
     res.setHeader('Content-Type', 'application/json');
 


### PR DESCRIPTION
## Problem

When the godot-mcp-server fails to start the WebSocket server (port 6505) or HTTP server (port 6506) with an error other than `EADDRINUSE`, the process continues running without listening on any ports. This creates a zombie process that cannot accept connections from Godot or proxy clients.

### Steps to Reproduce

1. Start godot-mcp-server
2. Trigger an error during WebSocket server startup (e.g., permission issue, ws library error)
3. Observe process is running but ports 6505/6506 are not listening

### Expected Behavior

The server should exit with a clear error if critical servers fail to start.

### Actual Behavior

Process continues running with no listening ports, waiting indefinitely for connections that can never be established.

### Workaround

```bash
pkill -f godot-mcp-server
npx godot-mcp-server
```

## Changes

- **Add `isListening()` method to `PrimaryHttpServer` class** - Allows checking if the HTTP server is actually listening
- **Add verification check after server startup attempts** - Ensures at least one server (WebSocket or HTTP) is listening
- **Exit with clear error if both servers fail** - Prevents zombie server state
- **Log warnings when individual servers fail** - Provides feedback when one server works but the other doesn't

## Testing

Built and verified the changes compile successfully. The verification logic checks:
1. WebSocket server listening on configured port
2. HTTP server listening on configured port
3. Exits with error if neither is listening
4. Continues with warnings if only one is listening

## Related

This complements existing fixes for zombie server issues in v0.2.7, v0.2.8, and v0.3.0, but addresses the edge case of non-port-conflict startup failures.