### PR TITLE
feat: add run_scene tool for headless subprocess execution

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "godot-mcp-server",
-  "version": "0.1.0",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "godot-mcp-server",
-      "version": "0.1.0",
+      "version": "0.2.7",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@modelcontextprotocol/sdk": "~1.25.2",
         "ws": "^8.18.0"
       },
       "bin": {
@@ -824,7 +824,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1609,7 +1608,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -23,7 +23,9 @@ import {
   McpError
 } from '@modelcontextprotocol/sdk/types.js';
 
-import { execSync } from 'child_process';
+import { execSync, spawn } from 'child_process';
+import { existsSync } from 'fs';
+import { join } from 'path';
 import { allTools, toolExists } from './tools/index.js';
 import { GodotBridge } from './godot-bridge.js';
 import { serveVisualization, stopVisualizationServer, setGodotBridge } from './visualizer-server.js';
@@ -112,6 +114,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }, null, 2)
       }]
     };
+  }
+
+  // Handle run_scene — spawns a headless subprocess, bypasses the bridge
+  if (name === 'run_scene') {
+    return handleRunScene(toolArgs, godotBridge);
   }
 
   // Validate tool exists
@@ -234,6 +241,183 @@ function killProcessOnPort(port: number): boolean {
     // No process on port, or kill failed — either way, proceed
   }
   return false;
+}
+
+/**
+ * Locate the Godot executable.
+ * Search order:
+ *   1. GODOT_PATH env var (explicit override, best for CI)
+ *   2. GODOT4_PATH env var (common alias)
+ *   3. `godot4` / `godot` on PATH
+ *   4. Platform-specific default install locations
+ */
+function findGodotExecutable(): string | null {
+  // Env overrides
+  const envPath = process.env.GODOT_PATH || process.env.GODOT4_PATH;
+  if (envPath && existsSync(envPath)) return envPath;
+
+  // PATH candidates
+  const pathCandidates = ['godot4', 'godot'];
+  for (const bin of pathCandidates) {
+    try {
+      const found = execSync(
+        process.platform === 'win32' ? `where ${bin}` : `which ${bin}`,
+        { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+      ).trim().split('\n')[0];
+      if (found && existsSync(found)) return found;
+    } catch {
+      // not on PATH — continue
+    }
+  }
+
+  // Platform-specific defaults
+  if (process.platform === 'darwin') {
+    const macPaths = [
+      '/Applications/Godot.app/Contents/MacOS/Godot',
+      '/Applications/Godot_v4.app/Contents/MacOS/Godot',
+    ];
+    for (const p of macPaths) {
+      if (existsSync(p)) return p;
+    }
+  } else if (process.platform === 'linux') {
+    const linuxPaths = ['/usr/bin/godot4', '/usr/bin/godot', '/usr/local/bin/godot4', '/usr/local/bin/godot'];
+    for (const p of linuxPaths) {
+      if (existsSync(p)) return p;
+    }
+  } else if (process.platform === 'win32') {
+    const winPaths = [
+      'C:\\Program Files\\Godot\\Godot.exe',
+      'C:\\Program Files (x86)\\Godot\\Godot.exe',
+    ];
+    for (const p of winPaths) {
+      if (existsSync(p)) return p;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Execute run_scene: spawn a headless Godot subprocess and capture output.
+ */
+async function handleRunScene(
+  toolArgs: Record<string, unknown>,
+  bridge: GodotBridge
+): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
+  const scenePath = toolArgs.scene_path as string;
+  const extraArgs = (toolArgs.args as string[] | undefined) ?? [];
+  const timeoutMs = (toolArgs.timeout_ms as number | undefined) ?? 60000;
+  const headless = (toolArgs.headless as boolean | undefined) ?? true;
+  const explicitProjectPath = toolArgs.project_path as string | undefined;
+
+  // Resolve project root: explicit param → bridge → error
+  const projectPath = explicitProjectPath || bridge.getStatus().projectPath;
+  if (!projectPath) {
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          error: 'Project path unknown. Either open the Godot editor with the MCP plugin connected, or pass project_path explicitly.',
+          hint: 'project_path should be the absolute filesystem path to the directory containing project.godot'
+        }, null, 2)
+      }],
+      isError: true
+    };
+  }
+
+  const godotBin = findGodotExecutable();
+  if (!godotBin) {
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          error: 'Godot executable not found.',
+          hint: 'Set the GODOT_PATH environment variable to the absolute path of your Godot binary, or ensure `godot4` / `godot` is on your PATH.'
+        }, null, 2)
+      }],
+      isError: true
+    };
+  }
+
+  // Build argument list:
+  //   godot [--headless] --path <project_root> [-s] <scene_path> [extra_args...]
+  // .gd scripts use -s (script mode); .tscn scenes are positional arguments.
+  const isScript = scenePath.endsWith('.gd');
+  const godotArgs: string[] = [];
+  if (headless) godotArgs.push('--headless');
+  godotArgs.push('--path', projectPath);
+  if (isScript) godotArgs.push('-s');
+  godotArgs.push(scenePath);
+  godotArgs.push(...extraArgs);
+
+  const startTime = Date.now();
+
+  return new Promise((resolve) => {
+    let stdout = '';
+    let timedOut = false;
+
+    const child = spawn(godotBin, godotArgs, {
+      // Merge stderr into stdout so print() and push_error() both appear
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+    child.stderr.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+    }, timeoutMs);
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      const duration_ms = Date.now() - startTime;
+
+      if (timedOut) {
+        resolve({
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              error: `Process timed out after ${timeoutMs}ms`,
+              stdout,
+              exit_code: null,
+              duration_ms
+            }, null, 2)
+          }],
+          isError: true
+        });
+        return;
+      }
+
+      resolve({
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            stdout,
+            exit_code: code,
+            duration_ms,
+            godot_bin: godotBin,
+            command: [godotBin, ...godotArgs].join(' ')
+          }, null, 2)
+        }]
+      });
+    });
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      resolve({
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            error: `Failed to spawn Godot: ${err.message}`,
+            godot_bin: godotBin,
+            command: [godotBin, ...godotArgs].join(' ')
+          }, null, 2)
+        }],
+        isError: true
+      });
+    });
+  });
 }
 
 /**

--- a/mcp-server/src/tools/index.ts
+++ b/mcp-server/src/tools/index.ts
@@ -8,6 +8,7 @@ import { scriptTools } from './script-tools.js';
 import { projectTools } from './project-tools.js';
 import { assetTools } from './asset-tools.js';
 import { visualizerTools } from './visualizer-tools.js';
+import { runnerTools } from './runner-tools.js';
 import type { ToolDefinition } from '../types.js';
 
 export const allTools: ToolDefinition[] = [
@@ -17,6 +18,7 @@ export const allTools: ToolDefinition[] = [
   ...projectTools,
   ...assetTools,
   ...visualizerTools,
+  ...runnerTools,
 ];
 
 export function toolExists(toolName: string): boolean {

--- a/mcp-server/src/tools/runner-tools.ts
+++ b/mcp-server/src/tools/runner-tools.ts
@@ -1,0 +1,49 @@
+/**
+ * Scene/script runner tool for Godot MCP Server
+ * Spawns a headless Godot subprocess and captures its output.
+ * Runs independently of the GodotBridge WebSocket — handled inline in index.ts.
+ */
+
+import type { ToolDefinition } from '../types.js';
+
+export const runnerTools: ToolDefinition[] = [
+  {
+    name: 'run_scene',
+    description: [
+      'Run a Godot scene or GDScript in a headless subprocess and return its full output.',
+      'Ideal for executing GUT test suites and reading pass/fail results without leaving the MCP session.',
+      'The Godot editor does not need to be open — but the project path must be known (connect the editor first, or pass project_path explicitly).',
+      '',
+      'Examples:',
+      '  Run GUT tests: scene_path="res://addons/gut/gut_cmdln.gd", args=["-gdir=res://tests/", "-gprefix=test_", "-gexit", "-glog=1"]',
+      '  Run a scene:   scene_path="res://scenes/Main.tscn"',
+    ].join('\n'),
+    inputSchema: {
+      type: 'object',
+      properties: {
+        scene_path: {
+          type: 'string',
+          description: 'res:// path to the scene (.tscn) or script (.gd) to run'
+        },
+        args: {
+          type: 'array',
+          items: { type: 'string', description: 'A single CLI argument string' },
+          description: 'Additional CLI arguments forwarded to the scene/script (e.g. ["-gdir=res://tests/", "-gexit"])'
+        },
+        timeout_ms: {
+          type: 'number',
+          description: 'Kill the process after this many milliseconds (default: 60000)'
+        },
+        headless: {
+          type: 'boolean',
+          description: 'Run without a display using --headless (default: true)'
+        },
+        project_path: {
+          type: 'string',
+          description: 'Absolute filesystem path to the Godot project root (contains project.godot). Auto-detected when Godot editor is connected.'
+        }
+      },
+      required: ['scene_path']
+    }
+  }
+];


### PR DESCRIPTION
## Summary

- Adds a new `run_scene` MCP tool that spawns a Godot headless subprocess and captures its full stdout/stderr output
- Enables agents to run GUT test suites and read pass/fail results without leaving the MCP session
- Tool bypasses the GodotBridge WebSocket entirely — runs as a pure Node.js child process, so the Godot editor does not need to be open

## How it works

```
run_scene(
  scene_path: "res://addons/gut/gut_cmdln.gd",
  args: ["-gdir=res://tests/", "-gprefix=test_", "-gsuffix=.gd", "-gexit", "-glog=1"]
)
```

Returns `{ stdout, exit_code, duration_ms, command }` — raw output the agent can parse for `[Failed]:` lines.

**Godot binary discovery order:**
1. `GODOT_PATH` / `GODOT4_PATH` env var (best for CI)
2. `godot4` / `godot` on PATH
3. Platform-specific defaults (`/Applications/Godot.app/...` on macOS, etc.)

**Project path resolution:** uses `project_path` param if provided, otherwise reads from the connected GodotBridge.

## Test plan

- [ ] Run GUT test suite via `run_scene` and verify stdout contains pass/fail output
- [ ] Verify timeout kills the process and returns partial stdout
- [ ] Verify error is returned when Godot binary is not found
- [ ] Verify `.tscn` scenes and `.gd` scripts both work (different CLI flag handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)